### PR TITLE
fix: update references to manifest to user proper terminology

### DIFF
--- a/cmd/dbc/driver_list.go
+++ b/cmd/dbc/driver_list.go
@@ -24,11 +24,11 @@ func GetDriverList(fname string) ([]dbc.PkgInfo, error) {
 	var m DriversList
 	f, err := os.Open(fname)
 	if err != nil {
-		return nil, fmt.Errorf("error opening manifest file %s: %w", fname, err)
+		return nil, fmt.Errorf("error opening driver list %s: %w", fname, err)
 	}
 	defer f.Close()
 	if err = toml.NewDecoder(f).Decode(&m); err != nil {
-		return nil, fmt.Errorf("error decoding manifest file %s: %w", fname, err)
+		return nil, fmt.Errorf("error decoding driver list %s: %w", fname, err)
 	}
 
 	drivers, err := dbc.GetDriverList()

--- a/cmd/dbc/driver_list_test.go
+++ b/cmd/dbc/driver_list_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnmarshalManifestList(t *testing.T) {
+func TestUnmarshalDriverList(t *testing.T) {
 	tests := []struct {
 		name     string
 		contents string
@@ -37,10 +37,10 @@ func TestUnmarshalManifestList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpdir := t.TempDir()
-			manifestPath := filepath.Join(tmpdir, "manifest.txt")
-			require.NoError(t, os.WriteFile(manifestPath, []byte(tt.contents), 0644))
+			driverListPath := filepath.Join(tmpdir, "dbc.toml")
+			require.NoError(t, os.WriteFile(driverListPath, []byte(tt.contents), 0644))
 
-			pkgs, err := GetDriverList(manifestPath)
+			pkgs, err := GetDriverList(driverListPath)
 			if tt.err != nil {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.err.Error())
@@ -72,7 +72,7 @@ func must[T any](v T, err error) T {
 	return v
 }
 
-func TestMarshalManifestList(t *testing.T) {
+func TestMarshalDriverManifestList(t *testing.T) {
 	data, err := toml.Marshal(DriversList{
 		Drivers: map[string]driverSpec{
 			"flightsql": {Version: must(semver.NewConstraint(">=1.6.0"))},


### PR DESCRIPTION
Updates code where we refer to "driver list" as a manifest.

Follow-on to https://github.com/columnar-tech/dbc/issues/21