### PR TITLE
fix: standardize copyright notices

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies, Inc.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Deploy
 

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Dev PR
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Go
 on:

--- a/.github/workflows/publish_install_script.yml
+++ b/.github/workflows/publish_install_script.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies, Inc.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Publish install.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies, Inc.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Release dbc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies, Inc.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 FROM scratch
 ENTRYPOINT ["/dbc"]
 COPY dbc /

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # dbc <picture><img src="resources/dbc_logo_animated.png?raw=true" align="right" alt="dbc Logo"/></picture>
 

--- a/cmd/dbc/add.go
+++ b/cmd/dbc/add.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/add_test.go
+++ b/cmd/dbc/add_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/driver_list.go
+++ b/cmd/dbc/driver_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/driver_list_test.go
+++ b/cmd/dbc/driver_list_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/init.go
+++ b/cmd/dbc/init.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/init_test.go
+++ b/cmd/dbc/init_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/install.go
+++ b/cmd/dbc/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/lockfile.go
+++ b/cmd/dbc/lockfile.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/main_test.go
+++ b/cmd/dbc/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/registry_test.go
+++ b/cmd/dbc/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 //go:build windows && test_registry
 

--- a/cmd/dbc/remove.go
+++ b/cmd/dbc/remove.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/search.go
+++ b/cmd/dbc/search.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/search_test.go
+++ b/cmd/dbc/search_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/subcommand_test.go
+++ b/cmd/dbc/subcommand_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/sync.go
+++ b/cmd/dbc/sync.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/sync_test.go
+++ b/cmd/dbc/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/tui_driver_list.go
+++ b/cmd/dbc/tui_driver_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/tui_menu.go
+++ b/cmd/dbc/tui_menu.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/uninstall.go
+++ b/cmd/dbc/uninstall.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/uninstall_test.go
+++ b/cmd/dbc/uninstall_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/cmd/dbc/view_config.go
+++ b/cmd/dbc/view_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package main
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/current.go
+++ b/config/current.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/dirs_unixlike.go
+++ b/config/dirs_unixlike.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 //go:build !windows
 

--- a/config/dirs_windows.go
+++ b/config/dirs_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/driver.go
+++ b/config/driver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/driver_test.go
+++ b/config/driver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package config
 

--- a/config/unixlike_test.go
+++ b/config/unixlike_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 //go:build !windows
 

--- a/delegates.go
+++ b/delegates.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package dbc
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # dbc docs
 

--- a/docs/concepts/driver.md
+++ b/docs/concepts/driver.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Driver
 

--- a/docs/concepts/driver_manager.md
+++ b/docs/concepts/driver_manager.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Driver Manager
 

--- a/docs/concepts/driver_manifest.md
+++ b/docs/concepts/driver_manifest.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Driver Manifest
 

--- a/docs/concepts/drivers_list.md
+++ b/docs/concepts/drivers_list.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Drivers List
 

--- a/docs/getting_started/faq.md
+++ b/docs/getting_started/faq.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # FAQ
 

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # First Steps
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Installation
 

--- a/docs/guides/drivers_list.md
+++ b/docs/guides/drivers_list.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Using the Drivers List
 

--- a/docs/guides/finding_drivers.md
+++ b/docs/guides/finding_drivers.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Finding Drivers
 

--- a/docs/guides/installing.md
+++ b/docs/guides/installing.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Installing Drivers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # dbc
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 <!--
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # Config
 

--- a/docs/reference/dbc.toml.md
+++ b/docs/reference/dbc.toml.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2025 Columnar Technologies.  All rights reserved. -->
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
 
 # dbc.toml
 

--- a/drivers.go
+++ b/drivers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+// Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 package dbc
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 site_name: dbc
 site_author: columnar-tech
@@ -6,7 +6,7 @@ site_description: dbc is a command line tool for installing and managing ADBC dr
 site_url: https://docs.columnar.tech/dbc
 repo_url: https://github.com/columnar-tech/dbc
 repo_name: dbc
-copyright: Copyright &copy; 2025 Columnar Technologies, Inc.
+copyright: Copyright &copy; 2025 Columnar Technologies Inc.
 markdown_extensions:
   - admonition
   - def_list

--- a/scripts/create_wheels.py
+++ b/scripts/create_wheels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Columnar Technologies.  All rights reserved.
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 # /// script
 # requires-python = ">=3.5"


### PR DESCRIPTION
This changes all instances of `Columnar Technologies.` and `Columnar Technologies, Inc.` to the canonical `Columnar Technologies Inc.`.