### PR TITLE
chore: add pre-commit workflow to ci for license checks

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.x"
       - name: Install
         run: pip install pre-commit
       - name: pre-commit (cache)
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: "3.x"
       - name: Install
         run: pip install pre-commit
       - name: pre-commit (cache)
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Dev
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+
+name: Dev
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: "Run pre-commit"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install
+        run: pip install pre-commit
+      - name: pre-commit (cache)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: pre-commit
+        run: |
+            pre-commit run --all-files --color=always --show-diff-on-failure --verbose

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
 
 name: Publish Docs
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Publish Docs
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ builds:
     goos:
       - linux
       - windows
-      - darwin      
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -65,9 +65,9 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}-{{ .Version }}
     files:
-      - 'LICENSE*'
-      - 'README*'
-      - src: '{{ .ArtifactPath }}*.sig'
+      - "LICENSE*"
+      - "README*"
+      - src: "{{ .ArtifactPath }}*.sig"
         strip_parent: true
     # use zip for windows archives
     format_overrides:
@@ -100,7 +100,15 @@ binary_signs:
   - id: signs
     if: '{{ ne .Os "windows" }}'
     signature: '${artifact}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}.sig'
-    args: ["--output", "${signature}", "-u", "hello@columnar.tech", "--detach-sign", "${artifact}"]
+    args:
+      [
+        "--output",
+        "${signature}",
+        "-u",
+        "hello@columnar.tech",
+        "--detach-sign",
+        "${artifact}",
+      ]
     stdin: "{{ .Env.SIGNING_PASSWORD }}"
 
 changelog:
@@ -122,24 +130,24 @@ changelog:
 
 dockers:
   - image_templates:
-    - "columnar/dbc:{{ .Version }}-amd64"
+      - "columnar/dbc:{{ .Version }}-amd64"
     use: buildx
     dockerfile: Dockerfile
     skip_push: false
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
-    - "columnar/dbc:{{ .Tag }}-amd64"
-    - "columnar/dbc:v{{ .Major }}-amd64"
-    - "columnar/dbc:v{{ .Major }}.{{ .Minor }}-amd64"
-    - "columnar/dbc:latest-amd64"
+      - "columnar/dbc:{{ .Tag }}-amd64"
+      - "columnar/dbc:v{{ .Major }}-amd64"
+      - "columnar/dbc:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "columnar/dbc:latest-amd64"
     use: buildx
     dockerfile: Dockerfile
     skip_push: auto
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
-    - "columnar/dbc:{{ .Version }}-arm64v8"
+      - "columnar/dbc:{{ .Version }}-arm64v8"
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile
@@ -147,10 +155,10 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64/v8"
   - image_templates:
-    - "columnar/dbc:{{ .Tag }}-arm64v8"
-    - "columnar/dbc:v{{ .Major }}-arm64v8"
-    - "columnar/dbc:v{{ .Major }}.{{ .Minor }}-arm64v8"
-    - "columnar/dbc:latest-arm64v8"
+      - "columnar/dbc:{{ .Tag }}-arm64v8"
+      - "columnar/dbc:v{{ .Major }}-arm64v8"
+      - "columnar/dbc:v{{ .Major }}.{{ .Minor }}-arm64v8"
+      - "columnar/dbc:latest-arm64v8"
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile
@@ -255,14 +263,37 @@ signs:
     artifacts: archive
     ids:
       - archives
-    args: ["--output", "${signature}", "-u", "hello@columnar.tech", "--detach-sign", "${artifact}"]
+    args:
+      [
+        "--output",
+        "${signature}",
+        "-u",
+        "hello@columnar.tech",
+        "--detach-sign",
+        "${artifact}",
+      ]
   - id: sign-windows-msi
     if: '{{ isEnvSet "SM_API_KEY" }}'
     artifacts: installer # Windows MSI installers
     cmd: jsign
-    args: ["-keystore", "{{ .Env.PKCS11_CONFIG }}",
-      "-storepass", "NONE", "-storetype", "PKCS11", "-alg", "SHA-256", "-tsaurl", "http://timestamp.digicert.com",
-      "--name", "{{ .ProjectName }} Installer", "-alias", "{{ .Env.SM_KEYPAIR_ALIAS }}", "${artifact}"]
+    args:
+      [
+        "-keystore",
+        "{{ .Env.PKCS11_CONFIG }}",
+        "-storepass",
+        "NONE",
+        "-storetype",
+        "PKCS11",
+        "-alg",
+        "SHA-256",
+        "-tsaurl",
+        "http://timestamp.digicert.com",
+        "--name",
+        "{{ .ProjectName }} Installer",
+        "-alias",
+        "{{ .Env.SM_KEYPAIR_ALIAS }}",
+        "${artifact}",
+      ]
 
 after:
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,15 @@ repos:
           - "--template"
           - >-
             Copyright \(c\) [YEAR] Columnar Technologies Inc\.  All rights reserved\.
+          - "--max_lines"
+          - "2"
+        exclude: |
+          (?x)^(
+              .*\.svg|
+              columnar\.pubkey|
+              scripts/install\.(ps1|sh)|
+              LICENSE|
+              go\.sum|
+              pixi\.lock|
+              resources/dbc\.wxs
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/amoeba/license-header-check
+    rev: 2e3be28cd7328424b5704881ed8ba789d8a52bfb
+    hooks:
+      - id: license-header-check
+        args:
+          - "--template"
+          - >-
+            Copyright \(c\) [YEAR] Columnar Technologies Inc\.  All rights reserved\.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/amoeba/license-header-check
-    rev: 2e3be28cd7328424b5704881ed8ba789d8a52bfb
+    rev: v0.1
     hooks:
       - id: license-header-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 repos:
   - repo: https://github.com/amoeba/license-header-check
@@ -8,7 +20,7 @@ repos:
         args:
           - "--template"
           - >-
-            Copyright \(c\) [YEAR] Columnar Technologies Inc\.  All rights reserved\.
+            Copyright [YEAR] Columnar Technologies Inc\.
           - "--max_lines"
           - "2"
         exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+
 repos:
   - repo: https://github.com/amoeba/license-header-check
     rev: v0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,18 @@
-<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
+<!--
+Copyright 2025 Columnar Technologies Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 
 # Contributing to dbc
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. -->
+
 # Contributing to dbc
 
 Thanks for choosing to contribute to dbc. Please read the following sections for more information on contributing.

--- a/cmd/dbc/testdata/test_index.yaml
+++ b/cmd/dbc/testdata/test_index.yaml
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 drivers:
   - name: Test Driver 1

--- a/cmd/dbc/testdata/test_index.yaml
+++ b/cmd/dbc/testdata/test_index.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+
 drivers:
   - name: Test Driver 1
     description: This is a test driver

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
+# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+
 mkdocs-material

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,15 @@
-# Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved.
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 mkdocs-material

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,18 @@
-/* Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. */
+/*
+Copyright 2025 Columnar Technologies Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 [data-md-color-scheme="slate"] {
   --md-default-bg-color: rgb(33, 33, 33);

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,5 @@
+/* Copyright (c) 2025 Columnar Technologies Inc.  All rights reserved. */
+
 [data-md-color-scheme="slate"] {
   --md-default-bg-color: rgb(33, 33, 33);
   --md-code-bg-color: rgb(45, 45, 45);

--- a/scripts/cdn.py
+++ b/scripts/cdn.py
@@ -117,7 +117,7 @@ def create_driver_index(output_dir: str, num_drivers: int, num_versions: int):
     # Create manifest.yaml
     manifest = {"drivers": drivers}
     manifest_path = output_path / "index.yaml"
-    
+
     with open(manifest_path, "w") as f:
         yaml.dump(manifest, f, default_flow_style=False, sort_keys=False)
 


### PR DESCRIPTION
Follow-on to https://github.com/columnar-tech/dbc/pull/73.

Adds a new GHA workflow to run pre-commit and a pre-commit config that runs https://github.com/amoeba/license-header-check/. Includes fixes to files that were missing licenses.