### PR TITLE
docs: re-enable search in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,3 +100,4 @@ exclude_docs: |
   README.md
 plugins:
   - privacy
+  - search


### PR DESCRIPTION
Search is enabled by default on mkdocs but it's disabled if you use any custom plugins (we do) so this-renables it. There are options for search but I think this is the right combo for now.

Closes #87