### PR TITLE
docs: fix issues introduced by https://github.com/columnar-tech/dbc/pull/89

### DIFF
--- a/docs/concepts/driver_list.md
+++ b/docs/concepts/driver_list.md
@@ -18,5 +18,6 @@ limitations under the License.
 
 The term "driver list" refers to the `dbc.toml` file managed by dbc. A driver list is ideal for checking into version control alongside your project.
 
-See the [Driver List](../guides/driver_list.md) guide to learn how to use a driver list.
+See the [driver list](../guides/driver_list.md) guide to learn how to use a driver list.
 
+See the [driver list](../reference/driver_list.md) reference for information about the format of the file.

--- a/docs/guides/driver_list.md
+++ b/docs/guides/driver_list.md
@@ -40,7 +40,7 @@ $ cat dbc.toml
 
 ```
 
-Driver lists uses the [TOML](https://toml.io) format and contains a TOML table of drivers. See the [Driver list](../reference/driver_list.md) for more detail.
+Driver lists uses the [TOML](https://toml.io) format and contains a TOML table of drivers. See the [driver list](../reference/driver_list.md) reference for more detail.
 
 ## Adding a Driver
 


### PR DESCRIPTION
https://github.com/columnar-tech/dbc/pull/89 introduced a couple of mistakes in the docs in order to make the build pass. This fixes those.

Note: The diff on 21 is unrelated but saves me creating a separate PR.