### PR TITLE
fix: add workaround for driver manager venv path bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build dbc
         run: |
-          go build -o dbc ./cmd/dbc
+          go build  ./cmd/dbc
         shell: bash
 
       - name: Run Integration Tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build dbc
         run: |
-          go build  ./cmd/dbc
+          go build ./cmd/dbc
         shell: bash
 
       - name: Run Integration Tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,60 @@
+# Copyright 2025 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Integration
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Build & Integrate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: 1.24.2
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build dbc
+        run: |
+          go build -o dbc ./cmd/dbc
+        shell: bash
+
+      - name: Run Integration Tests
+        run: ./ci/scripts/run_integration.sh
+        shell: bash

--- a/ci/scripts/run_integration.sh
+++ b/ci/scripts/run_integration.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eux
+
+python -m venv .venv
+
+if [ -f ".venv/bin/activate" ]; then
+  . ".venv/bin/activate"
+else
+  . ".venv/Scripts/activate"
+fi
+
+pip install adbc_driver_manager
+
+./dbc install duckdb
+
+python -c "from adbc_driver_manager import dbapi; dbapi.connect(driver=\"duckdb\");"


### PR DESCRIPTION
This works around a bug we identified with the 1.8.0 driver managers when using virtual environments. They are supposed to locate drivers in `$VIRTUAL_ENV/etc/adbc/drivers` but they look in `$VIRTUAL_ENV/etc/adbc/`. There may be a patch release soon to fix this but, in the mean time, we can work around this by symlinking manifests from `$VIRTUAL_ENV/etc/adbc/drivers` to `$VIRTUAL_ENV/etc/adbc/`. The manifests use absolute paths so it's fine.

This PR also adds an integration workflow which is how I tested my change. I don't think we want to run it on every single commit to the repo so we might discuss here when we might want to run something like this or if we want to run it in another repo.