### PR TITLE
chore: add workflow to preview docs PRs on Netlify

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -2,12 +2,9 @@ name: Deploy Docs Preview
 
 on:
   pull_request:
-    # paths:
-    #   - "src/**"
-    #   - "public/**"
-    #   - "package.json"
-    #   - "netlify.toml"
-    #   # Add other paths you want to monitor
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -7,6 +7,7 @@ on:
     #   - "public/**"
     #   - "package.json"
     #   - "netlify.toml"
+    #   # Add other paths you want to monitor
 
 permissions:
   contents: read

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  deployments: write
+  statuses: write
 
 jobs:
   deploy:

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -7,7 +7,6 @@ on:
     #   - "public/**"
     #   - "package.json"
     #   - "netlify.toml"
-    #   # Add other paths you want to monitor
 
 permissions:
   contents: read

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs Preview
+
+on:
+  pull_request:
+    # paths:
+    #   - "src/**"
+    #   - "public/**"
+    #   - "package.json"
+    #   - "netlify.toml"
+    #   # Add other paths you want to monitor
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: |
+          mkdocs build --strict
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654
+        with:
+          publish-dir: "./site"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Installation
 
-dbc itself is installable on the most common platforms and from a variety of sources.
+dbc can be installed on the most common platforms and from a variety of sources.
 
 ## Standalone Installer
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Installation
 
-dbc can be installed on the most common platforms and from a variety of sources.
+dbc itself is installable on the most common platforms and from a variety of sources.
 
 ## Standalone Installer
 


### PR DESCRIPTION
Creates a new workflow that publishes the docs to Netlify for PRs that touch paths related to the docs. Some things to note:

- When the deploy runs, a command gets added to the PR (see below)
- New comments aren't made when the preview is re-deployed
- The workflow also attaches a "deploy" to the PR so you can click the "View deployment" button (see below) to preview the page
- This is currently limited to running only on PRs not made from forks. i.e., if you want to update the docs and get previews, you have to push to columnar-tech, not a fork. This is because of the default behavior of secrets and Actions. If we wanted to relax this, we'd need to set up an Environment (I don't have access).

Closes https://github.com/columnar-tech/dbc/issues/62