### PR TITLE
docs: set up social image preview cards

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ github.ref }}
+          path: ~/.cache
       - name: Build site
         run: |
           mkdocs build --strict

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # dbc docs
 
 dbc uses [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) for docs.
-Building the docs requires a Python installation.
+Building the docs requires a Python installation and a number of system libraries for social image generation.
 
 ## Setup
 
@@ -28,6 +28,8 @@ uv venv
 source .venv/bin/activate
 uv pip install -r docs/requirements.txt
 ```
+
+Then install the necessary graphics libraries from https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#cairo-graphics.
 
 ## Building
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material
+mkdocs-material[imaging]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,3 +114,4 @@ extra_javascript:
 plugins:
   - privacy
   - search
+  - social


### PR DESCRIPTION
Enables the mkdocs-material [social plugin](https://squidfunk.github.io/mkdocs-material/plugins/social/) which produces a reasonable social media preview image for all pages. There's some customization ability we can follow up with where needed.

Outside of CI, this requires some setup so I've documented that. On GitHub Actions, the necessary dependencies should be available.

Also enables caching on GHA.

Closes #105 