### PR TITLE
docs: fix social image preview card on docs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+title: Documentation
+---
+
 <!--
 Copyright 2025 Columnar Technologies Inc.
 


### PR DESCRIPTION
This replaces the big text "Introduction" on our index page's social image preview with "Documentation". The other SEO tags for the page are unchanged as far as I can tell.