### PR TITLE
ci: close milestone fix kvstore value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,4 +236,4 @@ jobs:
             --if-match=$ETAG \
             --kvs-arn=${{ secrets.AWS_CF_KVSTORE_ARN }} \
             --key=latest \
-            --value=${{ fromJSON(steps.gorelease.outputs.metadata).tag }}
+            --value=${{ fromJSON(steps.gorelease.outputs.metadata).version }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -340,3 +340,11 @@ release:
     ---
 
     Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+
+milestones:
+  - repo:
+      owner: columnar-tech
+      name: dbc
+
+    close: true
+    name_template: "{{ .Version }}"


### PR DESCRIPTION
fix the kvstore label value

update goreleaser config to close the appropriate milestone during release.