### PR TITLE
chore: sort python imports

### DIFF
--- a/scripts/cdn.py
+++ b/scripts/cdn.py
@@ -17,9 +17,9 @@
 
 import argparse
 import tarfile
-import yaml
 from pathlib import Path
 
+import yaml
 from faker import Faker
 
 PLATFORMS = [

--- a/scripts/create_wheels.py
+++ b/scripts/create_wheels.py
@@ -50,18 +50,18 @@
 # ```
 
 import argparse
-from email.message import EmailMessage
 import hashlib
 import io
+import json
 import os
+import tarfile
 import urllib
 import urllib.request
-import json
-from wheel.wheelfile import WheelFile
-from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
-import tarfile
+from email.message import EmailMessage
 from typing import List
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
+from wheel.wheelfile import WheelFile
 
 GITHUB_ORG = "columnar-tech"
 GITHUB_REPO = "dbc"


### PR DESCRIPTION
Sort Python imports in accordance with [PEP 8](https://peps.python.org/pep-0008/#imports).