### PR TITLE
docs: document winget install option

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -122,6 +122,14 @@ You can also download the latest installer using the following URL:
 |--------------|---------------------------------------------------------|
 | `x64`        | <https://dbc.columnar.tech/latest/dbc-latest-x64.msi>   |
 
+## WinGet
+
+On Windows, you can install dbc using [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
+
+```console
+$ winget install dbc
+```
+
 ## Docker
 
 We publish [Docker](https://docker.io) images for each dbc release.
@@ -194,21 +202,27 @@ dbc can generate shell completions for a number of common shells.
 
 To remove dbc from your system, run the uninstall command corresponding to your installation method.
 
-=== "macOS / Linux (CLI)"
+=== "Linux/macOS shell"
 
     ```console
     $ rm $HOME/.local/bin/dbc
     ```
 
-=== "Windows (CLI)"
+=== "Windows shell"
 
     ```console
     $ powershell.exe -c "rm $HOME/.local/bin/dbc.exe"
     ```
 
-=== "Windows (MSI)"
+=== "Windows MSI"
 
     Go to **Settings** > **Apps** > **Installed apps** (or **Control Panel** > **Programs and Features**), select dbc, and click **Uninstall**.
+
+=== "WinGet"
+
+    ```console
+    $ winget uninstall dbc
+    ```
 
 === "uv"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,21 +24,27 @@ dbc is a command-line tool for installing and managing [ADBC](https://arrow.apac
 
 <br/>1. Install dbc (see [Installation](./getting_started/installation.md) for more options):
 
-=== "macOS / Linux (CLI)"
+=== "Linux/macOS shell"
 
     ```console
     $ curl -LsSf https://dbc.columnar.tech/install.sh | sh
     ```
 
-=== "Windows (CLI)"
+=== "Windows shell"
 
     ```console
     $ powershell -ExecutionPolicy ByPass -c "irm https://dbc.columnar.tech/install.ps1 | iex"
     ```
 
-=== "Windows (MSI)"
+=== "Windows MSI"
 
     Download <https://dbc.columnar.tech/latest/dbc-latest-x64.msi> and then run the installer.
+
+=== "WinGet"
+
+    ```console
+    $ winget install dbc
+    ```
 
 === "uv"
 
@@ -541,7 +547,7 @@ dbc is a command-line tool for installing and managing [ADBC](https://arrow.apac
         let mut driver = ManagedDriver::load_from_name("trino", ... )
         ```
 
-<br/>For a more detailed walkthrough on how to use dbc, check out our [First steps](./getting_started/first_steps.md) page or any of our [Guides](./guides).
+<br/>For a more detailed walkthrough on how to use dbc, check out our [First steps](./getting_started/first_steps.md) page or any of our [Guides](./guides/index.md).
 
 ## Features
 


### PR DESCRIPTION
This documents how to install and uninstall dbc with WinGet. Thanks @eitsupi for making this possible!

This also improves the naming of the install options a bit, and fixes an mkdocs build warning.