### PR TITLE
docs: fix incorrect language in cli docs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -177,7 +177,7 @@ $ dbc remove <DRIVER>
 
 `--path FILE`, `-p FILE`
 
-:   Driver list to add to [default: ./dbc.toml]
+:   Driver list to remove from [default: ./dbc.toml]
 
 ## sync
 


### PR DESCRIPTION
Caught this while looking at other things. The language here was probably
just copy pasted from the add docs.
