### PR TITLE
chore: update assertion in driver_list_test.go to fix tests

### DIFF
--- a/cmd/dbc/driver_list_test.go
+++ b/cmd/dbc/driver_list_test.go
@@ -42,7 +42,7 @@ func TestUnmarshalDriverList(t *testing.T) {
 			{Driver: dbc.Driver{Path: "flightsql"}, Version: semver.MustParse("1.8.0")},
 		}, nil},
 		{"greater", "[drivers]\nflightsql = {version = '>=1.8.0'}", []dbc.PkgInfo{
-			{Driver: dbc.Driver{Path: "flightsql"}, Version: semver.MustParse("1.8.0")},
+			{Driver: dbc.Driver{Path: "flightsql"}, Version: semver.MustParse("1.9.0")},
 		}, nil},
 	}
 


### PR DESCRIPTION
This gets tests passing but we should probably update the tests and implementation so it doesn't depend on the driver registry.