### PR TITLE
feat: don't show descriptions from non verbose search output

### DIFF
--- a/cmd/dbc/search.go
+++ b/cmd/dbc/search.go
@@ -131,7 +131,7 @@ func viewDrivers(d []dbc.Driver, verbose bool) string {
 		}
 
 		if !verbose {
-			l.Item(nameStyle.Render(driver.Path) + " - " + descStyle.Render(driver.Desc) + suffix)
+			l.Item(nameStyle.Render(driver.Path) + suffix)
 			continue
 		}
 

--- a/cmd/dbc/search_test.go
+++ b/cmd/dbc/search_test.go
@@ -24,11 +24,11 @@ func (suite *SubcommandTestSuite) TestSearchCmd() {
 	m := SearchCmd{}.GetModelCustom(
 		baseModel{getDriverRegistry: getTestDriverRegistry,
 			downloadPkg: downloadTestPkg})
-	suite.validateOutput("• test-driver-1 - This is a test driver\r\n"+
-		"• test-driver-2 - This is another test driver\r\n"+
-		"• test-driver-manifest-only - This is manifest-only driver\r\n"+
-		"• test-driver-no-sig - Driver manifest missing Files.signature entry\r\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\r\n\r ", "", suite.runCmd(m))
+	suite.validateOutput("• test-driver-1\r\n"+
+		"• test-driver-2\r\n"+
+		"• test-driver-manifest-only\r\n"+
+		"• test-driver-no-sig\r\n"+
+		"• test-driver-invalid-manifest\r\n\r ", "", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
@@ -39,10 +39,10 @@ func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
 	m = SearchCmd{}.GetModelCustom(
 		baseModel{getDriverRegistry: getTestDriverRegistry,
 			downloadPkg: downloadTestPkg})
-	suite.validateOutput("• test-driver-1 - This is a test driver [installed: env=>1.1.0]\r\n"+
-		"• test-driver-2 - This is another test driver\r\n• test-driver-manifest-only - This is manifest-only driver\r\n"+
-		"• test-driver-no-sig - Driver manifest missing Files.signature entry\r\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\r\n\r ", "", suite.runCmd(m))
+	suite.validateOutput("• test-driver-1 [installed: env=>1.1.0]\r\n"+
+		"• test-driver-2\r\n• test-driver-manifest-only\r\n"+
+		"• test-driver-no-sig\r\n"+
+		"• test-driver-invalid-manifest\r\n\r ", "", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdVerbose() {


### PR DESCRIPTION
Remove driver descriptions from the `dbc search` (non verbose) output.