### PR TITLE
chore: fix misspellings

### DIFF
--- a/cmd/dbc/search_test.go
+++ b/cmd/dbc/search_test.go
@@ -28,7 +28,7 @@ func (suite *SubcommandTestSuite) TestSearchCmd() {
 		"• test-driver-2 - This is another test driver\n"+
 		"• test-driver-manifest-only - This is manifest-only driver\n"+
 		"• test-driver-no-sig - Driver manifest missing Files.signature entry\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\n", suite.runCmd(m))
+		"• test-driver-invalid-manifest - This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
@@ -43,7 +43,7 @@ func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
 		"• test-driver-2 - This is another test driver\n"+
 		"• test-driver-manifest-only - This is manifest-only driver\n"+
 		"• test-driver-no-sig - Driver manifest missing Files.signature entry\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\n", suite.runCmd(m))
+		"• test-driver-invalid-manifest - This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdVerbose() {
@@ -63,7 +63,7 @@ func (suite *SubcommandTestSuite) TestSearchCmdVerbose() {
 		"Description: Driver manifest missing Files.signature entry\n   License: Apache-2.0\n   "+
 		"Available Versions:\n    ╰── 1.0.0\n"+
 		"• test-driver-invalid-manifest\n   Title: Test Driver Invalid Manifest\n   "+
-		"Description: This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\n   License: Apache-2.0\n   "+
+		"Description: This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n   License: Apache-2.0\n   "+
 		"Available Versions:\n    ╰── 1.0.0\n", suite.runCmd(m))
 }
 
@@ -96,7 +96,7 @@ func (suite *SubcommandTestSuite) TestSearchCmdVerboseWithInstalled() {
 		"    ╰── 1.0.0\n"+
 		"• test-driver-invalid-manifest\n"+
 		"   Title: Test Driver Invalid Manifest\n"+
-		"   Description: This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.\n"+
+		"   Description: This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n"+
 		"   License: Apache-2.0\n"+
 		"   Available Versions:\n"+
 		"    ╰── 1.0.0\n", suite.runCmd(m))

--- a/cmd/dbc/testdata/test_index.yaml
+++ b/cmd/dbc/testdata/test_index.yaml
@@ -74,7 +74,7 @@ drivers:
           - platform: windows_amd64
           - platform: windows_arm64
   - name: Test Driver Invalid Manifest
-    description: This is test driver with an invalid manfiest. See https://github.com/columnar-tech/dbc/issues/37.
+    description: This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.
     license: Apache-2.0
     path: test-driver-invalid-manifest
     pkginfo:

--- a/config/config.go
+++ b/config/config.go
@@ -342,7 +342,7 @@ func UninstallDriverShared(info DriverInfo) error {
 		// Run filepath.Clean on sharedPath mainly to catch inner ".." in the path
 		sharedPath = filepath.Clean(sharedPath)
 
-		// Don't remove anything that isn't contained withing the found driver's
+		// Don't remove anything that isn't contained within the found driver's
 		// config directory (i.e., avoid malicious driver manifests)
 		if !strings.HasPrefix(sharedPath, info.FilePath) {
 			continue

--- a/docs/concepts/driver_manifest.md
+++ b/docs/concepts/driver_manifest.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 The term "driver manifest" refers to an [ADBC Driver Manfifest](https://arrow.apache.org/adbc/current/format/driver_manifests.html).
 
-In short, a driver manfiest is a metadata file that stores key information about a driver, including the information a [Driver Manager](./driver_manager.md) needs to load it.
+In short, a driver manifest is a metadata file that stores key information about a driver, including the information a [Driver Manager](./driver_manager.md) needs to load it.
 
 For example, here's an example driver manifest for the MySQL ADBC driver:
 


### PR DESCRIPTION
Fix misspellings of "manifest" and "within".

These misspellings were detected by [Go Report Card](https://goreportcard.com/report/github.com/columnar-tech/dbc) which runs [misspell](https://github.com/client9/misspell).