### PR TITLE
docs: fix highlighting bug caused by 1Password for Chrome

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
-      pygments_lang_class: true
+      pygments_lang_class: false
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences


### PR DESCRIPTION
Ref #234 

1Password for Chrome started shipping what looks like code syntax highlighting with Prism.js. See my gist which has their latest JS bundle: https://gist.github.com/amoeba/3b06ca8fe7784dbaf3239918c2dfd5a8.

It appears this client side hook only runs when the element has a `language-*` class on it which we can remove by setting `pygments_lang_class` to false here. Our code blocks still get syntax highlighted so this shouldn't cause any noticeable change as far as I can tell. All of our syntax highlighting is done at build-time and handled on the client entirely with CSS.