### PR TITLE
docs: fix logo rendering issue in social preview images

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,4 +121,6 @@ extra_javascript:
 plugins:
   - privacy
   - search
-  - social
+  - social:
+      cards_layout_options:
+        logo: docs/assets/icon-512.png


### PR DESCRIPTION
We use the [social plugin](https://squidfunk.github.io/mkdocs-material/plugins/social/) to generate social preview images. By default, the logo it shows in the top right of the cards is just whatever you set in the `theme.logo` field. The SVG logo doesn't render correctly and gets clipped.

This patch overrides the default behavior to use the 512x512 logo we generated for site meta.

Closes #209

