### PR TITLE
chore: use upstream go-arg instead of fork

### DIFF
--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -135,7 +135,7 @@ type cmds struct {
 	Docs       *DocsCmd         `arg:"subcommand" help:"Open driver documentation in a web browser"`
 	Remove     *RemoveCmd       `arg:"subcommand" help:"Remove a driver from the driver list"`
 	Auth       *AuthCmd         `arg:"subcommand" help:"Manage driver registry credentials"`
-	Completion *completions.Cmd `arg:"subcommand" help:"-"`
+	Completion *completions.Cmd `arg:"subcommand,hidden"`
 	Quiet      bool             `arg:"-q,--quiet" help:"Suppress all output"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ toolchain go1.24.6
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/ProtonMail/gopenpgp/v3 v3.2.1
-	github.com/alexflint/go-arg v1.6.0
+	github.com/alexflint/go-arg v1.6.1
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.7
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -68,5 +68,3 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/alexflint/go-arg => github.com/zeroshade/go-arg v0.0.0-20251013220544-4735a7c3184f

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ProtonMail/go-crypto v1.2.0 h1:+PhXXn4SPGd+qk76TlEePBfOfivE0zkWFenhGh
 github.com/ProtonMail/go-crypto v1.2.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/ProtonMail/gopenpgp/v3 v3.2.1 h1:ohRlKL5YwyIkN5kk7uBvijiMsyA57mK0yBEJg9xButU=
 github.com/ProtonMail/gopenpgp/v3 v3.2.1/go.mod h1:x7RduTo/0n/2PjTFRoEHApaxye/8PFbhoCquwfYBUGM=
+github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
+github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
 github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
 github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -89,8 +91,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
-github.com/zeroshade/go-arg v0.0.0-20251013220544-4735a7c3184f h1:XI5fpJaulKcO2AJzuUM0O74hv/wt0XMEB8JkVigncW8=
-github.com/zeroshade/go-arg v0.0.0-20251013220544-4735a7c3184f/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
 github.com/zeroshade/machine-id v0.0.0-20250917170903-4283e98485ba h1:yStvOL+OyJJ41jmZVqHqAspXXr4VVKC3gIfnGvO/+Pw=
 github.com/zeroshade/machine-id v0.0.0-20250917170903-4283e98485ba/go.mod h1:RHX47A/DYmoTfyT25mb6C+Eve7X5miOporc+RVUoRoY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
We forked go-arg temporarily to add functionality we needed but that functionality is now in go-arg so we can switch back to it. This PR replaces the dependency and updates the cmds struct to use the new "hidden" feature added in go-arg v1.6.1. See https://github.com/alexflint/go-arg/releases/tag/v1.6.1.