### PR TITLE
fix(search): improve output for non-verbose

### DIFF
--- a/cmd/dbc/driver_list_test.go
+++ b/cmd/dbc/driver_list_test.go
@@ -41,7 +41,7 @@ func TestUnmarshalDriverList(t *testing.T) {
 		{"less", "[drivers]\nflightsql = {version = '<=1.8.0'}", []dbc.PkgInfo{
 			{Driver: dbc.Driver{Path: "flightsql"}, Version: semver.MustParse("1.8.0")},
 		}, nil},
-		{"greater", "[drivers]\nflightsql = {version = '>=1.8.0'}", []dbc.PkgInfo{
+		{"greater", "[drivers]\nflightsql = {version = '>=1.8.0, <1.10.0'}", []dbc.PkgInfo{
 			{Driver: dbc.Driver{Path: "flightsql"}, Version: semver.MustParse("1.9.0")},
 		}, nil},
 	}

--- a/cmd/dbc/search.go
+++ b/cmd/dbc/search.go
@@ -116,7 +116,8 @@ func viewDrivers(d []dbc.Driver, verbose bool) string {
 	installedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 
 	l := list.New()
-	t := table.New().Border(lipgloss.HiddenBorder())
+	t := table.New().Border(lipgloss.HiddenBorder()).
+		BorderTop(false).BorderBottom(false).BorderLeft(false).BorderRight(false)
 	for _, driver := range d {
 		var installed []string
 		installedVerbose := make(map[string][]string)

--- a/cmd/dbc/search_test.go
+++ b/cmd/dbc/search_test.go
@@ -24,12 +24,13 @@ func (suite *SubcommandTestSuite) TestSearchCmd() {
 	m := SearchCmd{}.GetModelCustom(
 		baseModel{getDriverRegistry: getTestDriverRegistry,
 			downloadPkg: downloadTestPkg})
-	suite.validateOutput("\r ", "• test-driver-1 - This is a test driver\n"+
-		"• test-driver-2 - This is another test driver\n"+
-		"• test-driver-manifest-only - This is manifest-only driver\n"+
-		"• test-driver-no-sig - Driver manifest missing Files.signature entry\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n"+
-		"• test-driver-docs-url - This is manifest-only with its docs_url key set\n", suite.runCmd(m))
+	suite.validateOutput("\r ",
+		"test-driver-1                This is a test driver                                                                             \n"+
+			"test-driver-2                This is another test driver                                                                       \n"+
+			"test-driver-manifest-only    This is manifest-only driver                                                                      \n"+
+			"test-driver-no-sig           Driver manifest missing Files.signature entry                                                     \n"+
+			"test-driver-invalid-manifest This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37. \n"+
+			"test-driver-docs-url         This is manifest-only with its docs_url key set                                                   \n", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
@@ -40,12 +41,13 @@ func (suite *SubcommandTestSuite) TestSearchCmdWithInstalled() {
 	m = SearchCmd{}.GetModelCustom(
 		baseModel{getDriverRegistry: getTestDriverRegistry,
 			downloadPkg: downloadTestPkg})
-	suite.validateOutput("\r ", "• test-driver-1 - This is a test driver [installed: env=>1.1.0]\n"+
-		"• test-driver-2 - This is another test driver\n"+
-		"• test-driver-manifest-only - This is manifest-only driver\n"+
-		"• test-driver-no-sig - Driver manifest missing Files.signature entry\n"+
-		"• test-driver-invalid-manifest - This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.\n"+
-		"• test-driver-docs-url - This is manifest-only with its docs_url key set\n", suite.runCmd(m))
+	suite.validateOutput("\r ",
+		"test-driver-1                This is a test driver                                                                              [installed: env=>1.1.0]\n"+
+			"test-driver-2                This is another test driver                                                                                               \n"+
+			"test-driver-manifest-only    This is manifest-only driver                                                                                              \n"+
+			"test-driver-no-sig           Driver manifest missing Files.signature entry                                                                             \n"+
+			"test-driver-invalid-manifest This is test driver with an invalid manifest. See https://github.com/columnar-tech/dbc/issues/37.                         \n"+
+			"test-driver-docs-url         This is manifest-only with its docs_url key set                                                                           \n", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestSearchCmdVerbose() {


### PR DESCRIPTION
supercedes #222 

Improves the output of `dbc search` when not using verbose mode:

<img width="1979" height="462" alt="image" src="https://github.com/user-attachments/assets/349e4f34-e1dd-4e4a-9b9f-28532db12c87" />
