### PR TITLE
fix: make dbc install tell the user how to start a license

### DIFF
--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -132,7 +132,7 @@ func (m baseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tea.Println(msgStyle.Render("Did you run `dbc auth login`?")))
 		case errors.Is(msg, dbc.ErrUnauthorizedColumnar):
 			cmd = tea.Sequence(tea.Println(errStyle.Render(msg.Error())),
-				tea.Println(msgStyle.Render("Installing this driver requires a license. Verify you have an active license at https://cloud.columnar.tech/account and run `dbc auth logout` and `dbc auth login` again make your license available. Contact support@columnar.tech if you need assistance.")))
+				tea.Println(msgStyle.Render("Installing this driver requires a license. Verify you have an active license at https://cloud.columnar.tech/account and try this command again. Contact support@columnar.tech if you need assistance.")))
 		default:
 			cmd = tea.Println(errStyle.Render("Error: " + msg.Error()))
 		}


### PR DESCRIPTION
A user can run into this error state when they try to install a driver without a license. It's pretty likely that they just need to start a trial, so I think the error message should tell them how to do that.

With this PR,

```
$ dbc install oracle
failed to download driver: dbc-cdn-private.columnar.tech/oracle/v0.4.3/oracle_macos_arm64_v0.4.3.tar.gz: not authorized to access
Installing this driver requires a license. Verify you have an active license at https://cloud.columnar.tech/account and run `dbc auth logout` and `dbc auth login` again make your license available. Contact support@columnar.tech if you need assistance.
exit status 1
```

Closes https://github.com/columnar-tech/dbc/issues/271
