### PR TITLE
chore: skip prereleases for homebrew casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -316,6 +316,7 @@ homebrew_casks:
     commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://columnar.tech/dbc"
     description: "A CLI utility for managing ADBC drivers"
+    skip_upload: auto # auto skips prereleases
     repository:
       owner: "columnar-tech"
       name: "homebrew-tap"


### PR DESCRIPTION
The old configuration pushed all releases to homebrew casks, regardless of whether they were prereleases or not. This change sets `skip_upload: auto`. From the [gorelease docs](https://goreleaser.com/customization/homebrew_casks/),

```
    # Setting this will prevent goreleaser to actually try to commit the updated
    # cask - instead, the cask file will be stored on the dist directory
    # only, leaving the responsibility of publishing it to the user.
    # If set to auto, the release will not be uploaded to the homebrew tap
    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
    #
    # Templates: allowed.
    skip_upload: true
```

I haven't tested this yet but it seems reasonable to set this to auto regardless.