### PR TITLE
fix: dockerfile tls errors and driver install errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM alpine:latest AS base
+
+# Notes
+# 1. `ca-certificates` is so we can use TLS (i.e., so dbc search works)
+# 2. Creating /tmp is so we can install drivers (dbc uses /tmp)
+RUN apk --update add ca-certificates && \
+  mkdir -p /tmp && \
+  chmod 1777 /tmp
+
 FROM scratch
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /tmp /tmp
 ENTRYPOINT ["/dbc"]
 COPY dbc /

--- a/resources/README.dockerhub.md
+++ b/resources/README.dockerhub.md
@@ -17,10 +17,44 @@ limitations under the License.
 [dbc](https://columnar.tech/dbc) is a command-line tool for installing and managing [ADBC](https://arrow.apache.org/adbc) drivers.
 This is the official set of Docker images for dbc.
 
+Note: These images are intended to be an easy way to run dbc and aren't designed for running typical analytical workloads inside the container. We recommend building your own images for more complicated use cases.
+
 ## Usage
 
+To run dbc and have it print its usage:
+
 ```sh
-docker run -it --rm columnar/dbc:latest dbc --help
+docker run -it --rm columnar/dbc:latest --help
+```
+
+To search for drivers,
+
+```sh
+docker run -it --rm columnar/dbc:latest search
+```
+
+To install a driver, a few extra flags must be set. The reason for this is that dbc's docker images are based on the scratch image which has no filesystem.
+
+Instead of attempting to install a driver into the container (which will fail), we mount a folder from our host (`$(pwd)/drivers`) into the container and specify that dbc should use that by setting the `ADBC_DRIVER_PATH` environment variable:
+
+```sh
+docker run --rm \
+    -v $(pwd)/drivers:/drivers \
+    -e ADBC_DRIVER_PATH=/drivers \
+    dbc:latest install sqlite
+```
+
+You should now see the sqlite driver installed _outside_ of the container,
+
+```sh
+$ tree drivers
+drivers
+├── sqlite_linux_arm64_v1.10.0
+│   ├── libadbc_driver_sqlite.so
+│   ├── libadbc_driver_sqlite.so.sig
+│   ├── LICENSE.txt
+│   └── NOTICE.txt
+└── sqlite.toml
 ```
 
 ## Image tags


### PR DESCRIPTION
Fixes the issue where running `dbc search` in the container would fail due to TLS errors. This is because we were missing the usual `ca-certificates` package because we use scratch and weren't copying it in. An alternative to what I did here without going to a full-feature base image would be to use the relatively new [distroless](https://github.com/GoogleContainerTools/distroless) container images.

The reason I didn't go that route is,

1. Slight size increase 13MB -> 19MB
2. It would change the container user from root to non-root which has implications for dbc behavior

While testing this fix, I also noticed that using this containerized version of DBC is a little bit confusing. So I updated the Dockerhub README to explain how to install drivers and make the purpose of the Docker image more clear.

Closes #274 