### PR TITLE
docs: add Databricks driver

### DIFF
--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -76,6 +76,7 @@ First, run `dbc search` to find the exact name of the driver:
 ```console
 $ dbc search
 • bigquery - An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
+• databricks - An ADBC Driver for Databricks developed by the ADBC Driver Foundry
 • duckdb - An ADBC driver for DuckDB developed by the DuckDB Foundation
 • flightsql - An ADBC driver for Apache Arrow Flight SQL developed under the Apache Software Foundation
 • mssql - An ADBC driver for Microsoft SQL Server developed by Columnar

--- a/docs/guides/finding_drivers.md
+++ b/docs/guides/finding_drivers.md
@@ -21,6 +21,7 @@ You can list the available drivers by running `dbc search`:
 ```console
 $ dbc search
 • bigquery - An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
+• databricks - An ADBC Driver for Databricks developed by the ADBC Driver Foundry
 • duckdb - An ADBC driver for DuckDB developed by the DuckDB Foundation
 • flightsql - An ADBC driver for Apache Arrow Flight SQL developed under the Apache Software Foundation
 • mssql - An ADBC driver for Microsoft SQL Server developed by Columnar
@@ -60,60 +61,84 @@ $ dbc search --verbose
    Description: An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
    License: Apache-2.0
    Available Versions:
-    ╰── 1.0.0
+    ├── 1.0.0
+    ╰── 1.10.0
+• databricks
+   Title: ADBC Driver Foundry Driver for Databricks
+   Description: An ADBC Driver for Databricks developed by the ADBC Driver Foundry
+   License: Apache-2.0
+   Available Versions:
+    ╰── 0.1.2
 • duckdb
    Title: DuckDB Driver
    Description: An ADBC driver for DuckDB developed by the DuckDB Foundation
    License: MIT
    Available Versions:
-    ╰── 1.4.0
+    ├── 1.4.0
+    ├── 1.4.1
+    ├── 1.4.2
+    ╰── 1.4.3
 • flightsql
    Title: ASF Apache Arrow Flight SQL Driver
    Description: An ADBC driver for Apache Arrow Flight SQL developed under the Apache Software Foundation
    License: Apache-2.0
    Available Versions:
-    ╰── 1.8.0
+    ├── 1.8.0
+    ├── 1.9.0
+    ╰── 1.10.0
 • mssql
    Title: Columnar Microsoft SQL Server Driver
    Description: An ADBC driver for Microsoft SQL Server developed by Columnar
    License: LicenseRef-PBL
    Available Versions:
-    ╰── 1.0.0
+    ├── 1.0.0
+    ├── 1.1.0
+    ╰── 1.2.0
 • mysql
    Title: ADBC Driver Foundry Driver for MySQL
    Description: An ADBC Driver for MySQL developed by the ADBC Driver Foundry
    License: Apache-2.0
    Available Versions:
-    ╰── 0.1.0
+    ├── 0.1.0
+    ╰── 0.2.0
 • postgresql
    Title: ASF PostgreSQL Driver
    Description: An ADBC driver for PostgreSQL developed under the Apache Software Foundation
    License: Apache-2.0
    Available Versions:
-    ╰── 1.8.0
+    ├── 1.8.0
+    ├── 1.9.0
+    ╰── 1.10.0
 • redshift
    Title: Columnar ADBC Driver for Amazon Redshift
    Description: An ADBC driver for Amazon Redshift developed by Columnar
    License: LicenseRef-PBL
    Available Versions:
-    ╰── 1.0.0
+    ├── 1.0.0
+    ╰── 1.1.0
 • snowflake
    Title: ASF Snowflake Driver
    Description: An ADBC driver for Snowflake developed under the Apache Software Foundation
    License: Apache-2.0
    Available Versions:
-    ╰── 1.8.0
+    ├── 1.8.0
+    ├── 1.9.0
+    ├── 1.10.0
+    ╰── 1.10.1
 • sqlite
    Title: ASF SQLite Driver
    Description: An ADBC driver for SQLite developed under the Apache Software Foundation
    License: Apache-2.0
    Available Versions:
     ├── 1.7.0
-    ╰── 1.8.0
+    ├── 1.8.0
+    ├── 1.9.0
+    ╰── 1.10.0
 • trino
    Title: ADBC Driver Foundry Driver for Trino
    Description: An ADBC Driver for Trino developed by the ADBC Driver Foundry
    License: Apache-2.0
    Available Versions:
-    ╰── 0.1.0
+    ├── 0.1.0
+    ╰── 0.2.0
 ```

--- a/docs/guides/installing.md
+++ b/docs/guides/installing.md
@@ -26,6 +26,7 @@ To find out what drivers are available, use `dbc search`:
 ```console
 $ dbc search
 • bigquery - An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
+• databricks - An ADBC Driver for Databricks developed by the ADBC Driver Foundry
 • duckdb - An ADBC driver for DuckDB developed by the DuckDB Foundation
 • flightsql - An ADBC driver for Apache Arrow Flight SQL developed under the Apache Software Foundation
 • mssql - An ADBC driver for Microsoft SQL Server developed by Columnar

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,62 @@ dbc is a command-line tool for installing and managing [ADBC](https://arrow.apac
         let mut driver = ManagedDriver::load_from_name("bigquery", ... )
         ```
 
+=== "Databricks"
+
+    ```console
+    $ dbc install databricks
+    ```
+
+    <br/>3. [Install a driver manager](./guides/driver_manager.md) and load drivers in any supported language:
+
+    === "C++"
+
+        ```cpp
+        #include <arrow-adbc/adbc.h>
+
+        AdbcDatabaseSetOption(&database, "driver", "databricks", &error)
+        ```
+
+    === "Go"
+
+        ```go
+        import . "github.com/apache/arrow-adbc/go/adbc/drivermgr"
+
+        db, _ := Driver{}.NewDatabase(map[string]string{"driver": "databricks", ... })
+        ```
+
+    === "Java"
+
+        ```java
+        import org.apache.arrow.adbc.driver.jni.JniDriver;
+
+        JniDriver.PARAM_DRIVER.set(params, "databricks");
+        ```
+
+    ===+ "Python"
+
+        ```python
+        from adbc_driver_manager import dbapi
+
+        con = dbapi.connect(driver="databricks", ... )
+        ```
+
+    === "R"
+
+        ```r
+        library(adbcdrivermanager)
+
+        drv <- adbc_driver("databricks")
+        ```
+
+    === "Rust"
+
+        ```rust
+        use adbc_driver_manager::ManagedDriver;
+
+        let mut driver = ManagedDriver::load_from_name("databricks", ... )
+        ```
+
 === "DuckDB"
 
     ```console


### PR DESCRIPTION
Adds the new Databricks driver to the docs. Updates `dbc search` outputs.