### PR TITLE
chore: don't override Version if set via ldflags

### DIFF
--- a/drivers.go
+++ b/drivers.go
@@ -87,7 +87,7 @@ func (u *uaRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func init() {
 	info, ok := debug.ReadBuildInfo()
-	if ok {
+	if ok && Version == "unknown" {
 		Version = info.Main.Version
 	}
 


### PR DESCRIPTION
This fixes a minor issue that prevents us from overriding `Version` with `ldflags` when we build from a source tarball. Right now, this is only useful for someone who might want to create a Homebrew formula for dbc because Homebrew builds from tarballs by default not from git.

This change makes the usual invocation of a build in a Brew formula work as expected,

```ruby
    ldflags = %W[
      -s -w
      -X github.com/columnar-tech/dbc.Version=v#{version}
    ]
    system "go", "build", *std_go_args(ldflags:), "./cmd/dbc"
```

Without this, dbc built with Homebrew would report,

```sh
$ /opt/homebrew/Cellar/dbc/0.1.0/bin/dbc --version
(devel)
```