### PR TITLE
docs: document the `--pre` option

### DIFF
--- a/docs/guides/driver_list.md
+++ b/docs/guides/driver_list.md
@@ -114,6 +114,8 @@ version = '=0.1.0'
 
 ## Pre-release Versions
 
+{{ since_version('v0.2.0') }}
+
 ### Allowing Pre-release Versions
 
 By default, when you add a driver to a driver list, dbc will only consider stable (non-pre-release) versions. If you want to allow pre-release versions when running `dbc sync`, use the `--pre` flag with `dbc add`:

--- a/docs/guides/finding_drivers.md
+++ b/docs/guides/finding_drivers.md
@@ -145,6 +145,8 @@ $ dbc search --verbose
 
 ### Pre-release Versions
 
+{{ since_version('v0.2.0') }}
+
 By default, `dbc search` hides pre-release versions from search results. Pre-release versions follow semantic versioning conventions and include version identifiers like `1.0.0-alpha.1`, `2.0.0-beta.3`, or `1.5.0-rc.1`.
 
 To include pre-release versions in search results, use the `--pre` flag:

--- a/docs/guides/installing.md
+++ b/docs/guides/installing.md
@@ -70,6 +70,8 @@ The syntax for specifying a version may be familiar to you if you've used other 
 
 ## Pre-release Versions
 
+{{ since_version('v0.2.0') }}
+
 ### Allowing Pre-release Versions
 
 By default, dbc acts as if pre-release versions don't exist when searching for and installing drivers. Pre-release versions follow semantic versioning conventions and include version identifiers like `1.0.0-alpha.1`, `2.0.0-beta.3`, or `1.5.0-rc.1`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,7 +70,7 @@ $ dbc search [FILTER]
 
 :   Print output as JSON instead of plaintext
 
-`--pre`
+`--pre` {{ since_version('v0.2.0') }}
 
 :   Include pre-release drivers and versions (hidden by default)
 
@@ -114,7 +114,7 @@ $ dbc install [OPTIONS] <DRIVER>
 
 :   Allow installation of drivers without a signature file
 
-`--pre`
+`--pre` {{ since_version('v0.2.0') }}
 
 :   Allow implicit installation of pre-release versions
 
@@ -196,7 +196,7 @@ $ dbc add <DRIVER>
 
 :   Driver list to add to [default: ./dbc.toml]
 
-`--pre`
+`--pre` {{ since_version('v0.2.0') }}
 
 :   Allow pre-release versions implicitly
 

--- a/docs/reference/driver_list.md
+++ b/docs/reference/driver_list.md
@@ -55,6 +55,8 @@ See [Version Constraints](../guides/installing.md#version-constraints) for the f
 
 ### `prerelease`
 
+{{ since_version('v0.2.0') }}
+
 Optional. Controls whether pre-release versions should be considered during version resolution.
 
 - When set to `'allow'`, dbc will consider pre-release versions when selecting which version to install


### PR DESCRIPTION
Adds documentation for the `--pre` option that was added to multiple subcommands.