### PR TITLE
docs: add notes about installing via winget

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -122,6 +122,10 @@ You can also download the latest installer using the following URL:
 |--------------|---------------------------------------------------------|
 | `x64`        | <https://dbc.columnar.tech/latest/dbc-latest-x64.msi>   |
 
+!!! note
+
+    Starting with dbc 0.2.0, the MSI installer only supports per-user installs. The 0.1.0 MSI installed system-wide.
+
 ## WinGet
 
 On Windows, you can install dbc using [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
@@ -129,6 +133,15 @@ On Windows, you can install dbc using [WinGet](https://learn.microsoft.com/en-us
 ```console
 $ winget install dbc
 ```
+
+!!! note
+
+    If you installed dbc 0.1.0 with WinGet, it was installed system-wide and `winget upgrade dbc` cannot upgrade it. Uninstall the system-level package first, then install again:
+
+    ```console
+    $ winget uninstall --id Columnar.dbc
+    $ winget install dbc
+    ```
 
 ## Docker
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,15 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
     $ winget install dbc
     ```
 
+    !!! note
+
+        If you installed dbc 0.1.0 with WinGet, uninstall the system-level package first and then reinstall 0.2.0:
+
+        ```console
+        $ winget uninstall --id Columnar.dbc
+        $ winget install dbc
+        ```
+
 === "uv"
 
     ```console


### PR DESCRIPTION
A follow up for #168.
Related to #17.

When we try to upgrade dbc from 0.1.0 to 0.2.0 via winget (`winget upgrade dbc`), the following message appears and the upgrade fails.

```
No applicable upgrade found.
A newer package version is available in a configured source, but it does not apply to your system or requirements.
```

We need to uninstall the system-level dbc 0.1.0 first.