### PR TITLE
fix: windows installer can't be uninstalled

### DIFF
--- a/resources/dbc.wxs
+++ b/resources/dbc.wxs
@@ -48,8 +48,8 @@ limitations under the License.
         <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
     </UI>
   </Fragment>
-           Manufacturer="Columnar Technologies Inc." Version="{{ .Version }}"
   <Product Id="*" Name="dbc" Language="1033"
+           Manufacturer="Columnar Technologies Inc." Version="{{ .Version }}"
            UpgradeCode="3BC2470F-54EE-47F0-973C-A789684BF95E">
 
     <Package InstallScope="perUser"


### PR DESCRIPTION
Updates our WiX template to fix an issue where dbc can't be uninstalled with Add/Remove programs. We were setting two values in our .wxs template incorrectly. The "Product Code" should vary between releases and the "Package Code" should as well. 

See:

- https://learn.microsoft.com/en-us/windows/win32/msi/productcode
- https://learn.microsoft.com/en-us/windows/win32/msi/package-codes

Closes #319 