### PR TITLE
feat: add version parameter to install scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -203,7 +203,8 @@ function Download($download_url, $platforms) {
     } catch [System.Net.WebException] {
         $statusCode = [int]$_.Exception.Response.StatusCode
         if ($statusCode -eq 403) {
-            throw "Error: dbc is not available for your platform: ($arch). Please create an issue at https://github.com/columnar-tech/dbc/issues or contact support@columnar.tech for assistance."
+            throw "Error: $app_name ($app_version) is either not available or not available for your platform: ($arch)." `
+                + "Double-check the version you've requested. Please create an issue at https://github.com/columnar-tech/dbc/issues or contact support@columnar.tech for assistance."
         }
         throw "Error: Failed to download $url. HTTP Status Code: $statusCode"
     }    

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1454,7 +1454,8 @@ downloader() {
     fi
 
     if [ "$SUCCESS" -ne 0 ] || [ "$HTTP_STATUS" -eq 403 ]; then
-        say "Error: dbc is not available for your platform. Please create an issue at https://github.com/columnar-tech/dbc/issues or contact support@columnar.tech for assistance."
+        say "Error: $APP_NAME ($APP_VERSION) is either not available or not available for your platform."
+        say "Double-check the version you've requested. Please create an issue at https://github.com/columnar-tech/dbc/issues or contact support@columnar.tech for assistance."
         exit 1
     fi
 }


### PR DESCRIPTION
## Summary

Adds version parameter support to both Windows and Unix install scripts, allowing users to install specific versions of dbc instead of always defaulting to 'latest'.

## Changes

### Windows PowerShell Script (`scripts/install.ps1`)
- Added `-Version` parameter to specify version (e.g., `0.2.0`, `v0.2.0`, or `latest`)
- Automatic normalization strips 'v'/'V' prefix from version strings
- Defaults to `'latest'` for backward compatibility
- Updated script help documentation

### Bash Script (`scripts/install.sh`)
- Added `--version` parameter to specify version (long form only to avoid conflict with `-v` verbose flag)
- Automatic normalization strips 'v'/'V' prefix from version strings
- Version format validation (semantic version or 'latest')
- Rejects empty/invalid versions with helpful error messages
- Defaults to `'latest'` for backward compatibility
- Updated help documentation with examples
- POSIX shell compliant

### Documentation
- Added version parameter examples to `docs/getting_started/installation.md`
- Added version parameter examples to `README.md`
- Shows download-then-run approach for Windows version-specific installs

## Usage Examples

**Windows:**
```powershell
# Default (latest)
.\install.ps1

# Specific version
.\install.ps1 -Version "0.2.0"

# With v prefix
.\install.ps1 -Version "v0.2.0"
```

**Linux/macOS:**
```bash
# Default (latest)
./install.sh

# Specific version
./install.sh --version 0.2.0

# With v prefix
./install.sh --version v0.2.0
```

## Testing

- ✅ Backward compatibility maintained (defaults to 'latest')
- ✅ Version normalization works across all formats
- ✅ Windows script help displays correctly
- ✅ Bash script version validation works
- ✅ POSIX shell compliance verified
- ✅ Documentation examples are accurate

## Commits

- feat: add -Version parameter to Windows install script
- docs: add examples for version parameter in Windows install
- feat: add APP_VERSION environment variable support
- refactor: remove APP_VERSION env var, keep only -Version param
- feat: add --version parameter to bash install script
- fix: improve version parameter validation and quoting
- fix: correct empty version string validation logic