### PR TITLE
fix: improve error when installing driver archive with subdirs

### DIFF
--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -410,4 +412,34 @@ func (suite *SubcommandTestSuite) TestInstallCompleteRegistryFailure() {
 
 	suite.Contains(out, "connection timeout")
 	suite.driverIsNotInstalled("test-driver-1")
+}
+
+func (suite *SubcommandTestSuite) TestInstallDriverWithSubdirectories() {
+	packageDir := suite.T().TempDir()
+	packagePath := filepath.Join(packageDir, "driver-with-subdir.tar.gz")
+
+	f, err := os.Create(packagePath)
+	suite.Require().NoError(err)
+	gzw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gzw)
+
+	// Just add the subdir as the only entry
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "subdir/",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	})
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(tw.Close())
+	suite.Require().NoError(gzw.Close())
+	suite.Require().NoError(f.Close())
+
+	// Should fail
+	m := InstallCmd{Driver: packagePath, NoVerify: true}.
+		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
+	out := suite.runCmdErr(m)
+
+	// and return an error with this
+	suite.Contains(out, "driver archives shouldn't contain subdirectories")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -267,6 +267,12 @@ func InflateTarball(f *os.File, outDir string) (Manifest, error) {
 			return m, fmt.Errorf("error reading tarball: %w", err)
 		}
 
+		// Return a helpful error if an entry is a directory. dbc doesn't support
+		// installing driver tarballs that contain directories.
+		if hdr.Typeflag == tar.TypeDir {
+			return m, fmt.Errorf("found a directory entry when trying to extract %s which isn't supported. driver archives shouldn't contain subdirectories", f.Name())
+		}
+
 		if hdr.Name != "MANIFEST" {
 			next, err := os.Create(filepath.Join(outDir, hdr.Name))
 			if err != nil {


### PR DESCRIPTION
dbc currently can't install driver archives with subfolders but the error message the user gets could be improved. This isn't a major issue since we've been the ones doing all the packaging but others could run into this if they start creating driver archives. This change makes the reason for the error explicit.