### PR TITLE
fix: improve dbc install error on driver not found

### DIFF
--- a/cmd/dbc/info_test.go
+++ b/cmd/dbc/info_test.go
@@ -38,7 +38,7 @@ func (suite *SubcommandTestSuite) TestInfo_DriverNotFound() {
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	out := suite.runCmdErr(m)
 
-	suite.validateOutput("\r ", "\nError: driver `non-existent-driver` not found in driver registry index", out)
+	suite.validateOutput("\r ", "\nError: driver `non-existent-driver` not found in driver registry index; try: `dbc search` to list available drivers", out)
 }
 
 func (suite *SubcommandTestSuite) TestInfoPartialRegistryFailure() {

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -39,7 +39,7 @@ func (suite *SubcommandTestSuite) TestInstall() {
 func (suite *SubcommandTestSuite) TestInstallDriverNotFound() {
 	m := InstallCmd{Driver: "foo", Level: suite.configLevel}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
-	suite.validateOutput("\r ", "\nError: could not find driver: driver `foo` not found in driver registry index", suite.runCmdErr(m))
+	suite.validateOutput("\r ", "\nError: could not find driver: driver `foo` not found in driver registry index; try: `dbc search` to list available drivers", suite.runCmdErr(m))
 	suite.driverIsNotInstalled("test-driver-1")
 }
 

--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -78,7 +78,7 @@ func findDriver(name string, drivers []dbc.Driver) (dbc.Driver, error) {
 	})
 
 	if idx == -1 {
-		return dbc.Driver{}, fmt.Errorf("driver `%s` not found in driver registry index", name)
+		return dbc.Driver{}, fmt.Errorf("driver `%s` not found in driver registry index; try: `dbc search` to list available drivers", name)
 	}
 	return drivers[idx], nil
 }


### PR DESCRIPTION
This improves the error message when a user tries to install a driver that doesn't exist in any registry. The current behavior is,

```sh
$ dbc install sqlserver
Error: could not find driver: driver `sqlserver` not found in driver registry index
```

With this PR, the new behavior is,

```
$ go run ./cmd/dbc install sqlserver
Error: could not find driver: driver `sqlserver` not found in driver registry index; try: `dbc search` to list available drivers
```