### PR TITLE
chore: automatically set --livereload flag in docs-serve task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -44,4 +44,4 @@ cairo = ">=1.18.4,<2"
 
 [feature.docs.tasks]
 docs-build = "mkdocs build"
-docs-serve = "mkdocs serve"
+docs-serve = "mkdocs serve --livereload"


### PR DESCRIPTION
When I use the docs-serve task, I always manually add --livereload because I want to see my changes reflected without a refresh. I think adding it as the default is fine to do.
