### PR TITLE
fix: clarify help text and docs for dbc add for multiple drivers

### DIFF
--- a/cmd/dbc/add.go
+++ b/cmd/dbc/add.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Masterminds/semver/v3"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/Masterminds/semver/v3"
 	"github.com/columnar-tech/dbc/config"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -42,7 +42,7 @@ func driverListPath(path string) (string, error) {
 }
 
 type AddCmd struct {
-	Driver []string `arg:"positional,required" help:"Driver to add"`
+	Driver []string `arg:"positional,required" help:"One or more drivers to add, optionally with a version constraint (for example: mysql, mysql=0.1.0, mysql>=1,<2)"`
 	Path   string   `arg:"-p" placeholder:"FILE" default:"./dbc.toml" help:"Driver list to add to"`
 	Pre    bool     `arg:"--pre" help:"Allow pre-release versions implicitly"`
 }

--- a/cmd/dbc/completions/dbc.fish
+++ b/cmd/dbc/completions/dbc.fish
@@ -31,7 +31,7 @@ complete -c dbc -n '__fish_dbc_needs_command' -l quiet -s q -d 'Suppress all out
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'install' -d 'Install a driver'
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'uninstall' -d 'Uninstall a driver'
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'init' -d 'Create new driver list'
-complete -f -c dbc -n '__fish_dbc_needs_command' -a 'add' -d 'Add a driver to the driver list'
+complete -f -c dbc -n '__fish_dbc_needs_command' -a 'add' -d 'Add one or more drivers to the driver list'
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'sync' -d 'Install all drivers in the driver list'
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'search' -d 'Search for drivers'
 complete -f -c dbc -n '__fish_dbc_needs_command' -a 'remove' -d 'Remove a driver from the driver list'

--- a/cmd/dbc/completions/dbc.zsh
+++ b/cmd/dbc/completions/dbc.zsh
@@ -16,7 +16,7 @@ function _dbc {
                 'install[Install a driver]' \
                 'uninstall[Uninstall a driver]' \
                 'init[Create new driver list]' \
-                'add[Add a driver to the driver list]' \
+                'add[Add one or more drivers to the driver list]' \
                 'sync[Install all drivers in the driver list]' \
                 'search[Search for drivers]' \
                 'info[Get detailed information about a specific driver]' \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -179,7 +179,7 @@ $ dbc init [PATH]
 
 ## add
 
-Add a driver to a current [driver list](../concepts/driver_list.md).
+Add one or more drivers to the current [driver list](../concepts/driver_list.md).
 
 <h3>Usage</h3>
 
@@ -191,7 +191,7 @@ $ dbc add <DRIVER>
 
 `DRIVER`
 
-:   Name of the driver to add. Can be a short driver name or a driver name with version requirement. Examples: `bigquery`, `bigquery=1.0.0`, `bigquery>1`.
+:   Name of one or more drivers to add. Can be a short driver name or a driver name with version requirement. Examples: `bigquery`, `bigquery=1.0.0`, `bigquery>1`.
 
 <h3>Options</h3>
 


### PR DESCRIPTION
Updates the help text and the CLI reference to better indicate that you can pass multiple drivers to `dbc add`. This keeps the variable as `Driver` even though "Drivers" might make more sense so we follow the go-arg convention for repeatable args.

Completions are also sync'd by this PR.