### PR TITLE
fix: use consistent number of trailing newlines in all subcommands

### DIFF
--- a/cmd/dbc/docs.go
+++ b/cmd/dbc/docs.go
@@ -164,7 +164,7 @@ func (m docsModel) FinalOutput() string {
 		} else {
 			docName = m.driver + " driver"
 		}
-		return fmt.Sprintf("%s docs are available at the following URL:\n%s\n", docName, m.urlToOpen)
+		return fmt.Sprintf("%s docs are available at the following URL:\n%s", docName, m.urlToOpen)
 	}
 	return ""
 }

--- a/cmd/dbc/info.go
+++ b/cmd/dbc/info.go
@@ -91,7 +91,7 @@ func formatDriverInfo(drv dbc.Driver) string {
 		b.WriteString("   - " + descStyle.Render(pkg.PlatformTuple) + "\n")
 	}
 
-	return b.String()
+	return strings.TrimSuffix(b.String(), "\n")
 }
 
 func driverInfoJSON(drv dbc.Driver) string {

--- a/cmd/dbc/info_test.go
+++ b/cmd/dbc/info_test.go
@@ -30,7 +30,7 @@ func (suite *SubcommandTestSuite) TestInfo() {
 		"License: MIT\nDescription: This is a test driver\n"+
 		"Available Packages:\n"+
 		"   - linux_amd64\n   - macos_amd64\n"+
-		"   - macos_arm64\n   - windows_amd64\n", out)
+		"   - macos_arm64\n   - windows_amd64", out)
 }
 
 func (suite *SubcommandTestSuite) TestInfo_DriverNotFound() {

--- a/cmd/dbc/install.go
+++ b/cmd/dbc/install.go
@@ -210,7 +210,7 @@ func (m progressiveInstallModel) FinalOutput() string {
 				return fmt.Sprintf(`{"status":"already installed","driver":"%s","version":"%s","location":"%s"}`,
 					m.conflictingInfo.ID, m.conflictingInfo.Version, filepath.SplitList(m.cfg.Location)[0])
 			}
-			return fmt.Sprintf("\nDriver %s %s already installed at %s\n",
+			return fmt.Sprintf("\nDriver %s %s already installed at %s",
 				m.conflictingInfo.ID, m.conflictingInfo.Version, filepath.SplitList(m.cfg.Location)[0])
 		}
 	}
@@ -250,11 +250,11 @@ func (m progressiveInstallModel) FinalOutput() string {
 			fmt.Fprintf(&b, "\nRemoved conflicting driver: %s", output.Conflict)
 		}
 
-		fmt.Fprintf(&b, "\nInstalled %s %s to %s\n",
+		fmt.Fprintf(&b, "\nInstalled %s %s to %s",
 			output.Driver, output.Version, output.Location)
 
 		if output.Message != "" {
-			b.WriteString("\n" + postMsgStyle.Render(output.Message) + "\n")
+			b.WriteString("\n\n" + postMsgStyle.Render(output.Message))
 		}
 	}
 	return b.String()

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -32,7 +32,7 @@ func (suite *SubcommandTestSuite) TestInstall() {
 	out := suite.runCmd(m)
 
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.1.0 to "+suite.Dir()+"\n", out)
+		"\nInstalled test-driver-1 1.1.0 to "+suite.Dir(), out)
 	suite.driverIsInstalled("test-driver-1", true)
 }
 
@@ -62,7 +62,7 @@ func (suite *SubcommandTestSuite) TestInstallWithVersion() {
 			out := suite.runCmd(m)
 
 			suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-				"\nInstalled test-driver-1 "+tt.expectedVersion+" to "+suite.Dir()+"\n", out)
+				"\nInstalled test-driver-1 "+tt.expectedVersion+" to "+suite.Dir(), out)
 			suite.driverIsInstalled("test-driver-1", true)
 			m = UninstallCmd{Driver: "test-driver-1", Level: suite.configLevel}.GetModelCustom(
 				baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
@@ -76,19 +76,19 @@ func (suite *SubcommandTestSuite) TestInstallWithVersionLessSpace() {
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	out := suite.runCmd(m)
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.0.0 to "+suite.tempdir+"\n", out)
+		"\nInstalled test-driver-1 1.0.0 to "+suite.tempdir, out)
 }
 
 func (suite *SubcommandTestSuite) TestReinstallUpdateVersion() {
 	m := InstallCmd{Driver: "test-driver-1<=1.0.0"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.0.0 to "+suite.tempdir+"\n", suite.runCmd(m))
+		"\nInstalled test-driver-1 1.0.0 to "+suite.tempdir, suite.runCmd(m))
 
 	m = InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nRemoved conflicting driver: test-driver-1 (version: 1.0.0)\nInstalled test-driver-1 1.1.0 to "+suite.tempdir+"\n",
+		"\nRemoved conflicting driver: test-driver-1 (version: 1.0.0)\nInstalled test-driver-1 1.1.0 to "+suite.tempdir,
 		suite.runCmd(m))
 
 	suite.Equal([]string{"test-driver-1.1/test-driver-1-not-valid.so",
@@ -102,7 +102,7 @@ func (suite *SubcommandTestSuite) TestInstallVenv() {
 	m := InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.1.0 to "+filepath.Join(suite.tempdir, "etc", "adbc", "drivers")+"\n", suite.runCmd(m))
+		"\nInstalled test-driver-1 1.1.0 to "+filepath.Join(suite.tempdir, "etc", "adbc", "drivers"), suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestInstallEnvironmentPrecedence() {
@@ -146,7 +146,7 @@ func (suite *SubcommandTestSuite) TestInstallCondaPrefix() {
 	m := InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.1.0 to "+filepath.Join(suite.tempdir, "etc", "adbc", "drivers")+"\n", suite.runCmd(m))
+		"\nInstalled test-driver-1 1.1.0 to "+filepath.Join(suite.tempdir, "etc", "adbc", "drivers"), suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestInstallManifestOnlyDriver() {
@@ -154,8 +154,8 @@ func (suite *SubcommandTestSuite) TestInstallManifestOnlyDriver() {
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-manifest-only 1.0.0 to "+suite.Dir()+"\n"+
-			"\nMust have libtest_driver installed to load this driver\n", suite.runCmd(m))
+		"\nInstalled test-driver-manifest-only 1.0.0 to "+suite.Dir()+
+			"\n\nMust have libtest_driver installed to load this driver", suite.runCmd(m))
 	suite.driverIsInstalled("test-driver-manifest-only", false)
 }
 
@@ -173,7 +173,7 @@ func (suite *SubcommandTestSuite) TestInstallDriverNoSignature() {
 	m = InstallCmd{Driver: "test-driver-no-sig", NoVerify: true}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[-] verifying signature\r\n",
-		"\nInstalled test-driver-no-sig 1.0.0 to "+suite.tempdir+"\n", suite.runCmd(m))
+		"\nInstalled test-driver-no-sig 1.0.0 to "+suite.tempdir, suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestInstallGitignoreDefaultBehavior() {
@@ -277,7 +277,7 @@ func (suite *SubcommandTestSuite) TestInstallLocalPackage() {
 
 	suite.validateOutput("Installing from local package: "+packagePath+"\r\n\r\n\r"+
 		"[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.0.0 to "+suite.Dir()+"\n", out)
+		"\nInstalled test-driver-1 1.0.0 to "+suite.Dir(), out)
 	suite.driverIsInstalled("test-driver-1", true)
 }
 
@@ -310,7 +310,7 @@ func (suite *SubcommandTestSuite) TestInstallLocalPackageNoSignature() {
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	suite.validateOutput("Installing from local package: "+packagePath+"\r\n\r\n\r"+
 		"[✓] installing\r\n[-] verifying signature\r\n",
-		"\nInstalled test-driver-no-sig 1.1.0 to "+suite.tempdir+"\n", suite.runCmd(m))
+		"\nInstalled test-driver-no-sig 1.1.0 to "+suite.tempdir, suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestInstallLocalPackageFixUpName() {
@@ -324,7 +324,7 @@ func (suite *SubcommandTestSuite) TestInstallLocalPackageFixUpName() {
 
 	suite.validateOutput("Installing from local package: "+packagePath+"\r\n\r\n\r"+
 		"[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.0.0 to "+suite.Dir()+"\n", out)
+		"\nInstalled test-driver-1 1.0.0 to "+suite.Dir(), out)
 	suite.driverIsInstalled("test-driver-1", true)
 }
 
@@ -335,7 +335,7 @@ func (suite *SubcommandTestSuite) TestInstallWithPreOnlyPrereleaseDriver() {
 	out := suite.runCmd(m)
 
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-only-pre 0.9.0-alpha.1 to "+suite.Dir()+"\n", out)
+		"\nInstalled test-driver-only-pre 0.9.0-alpha.1 to "+suite.Dir(), out)
 	suite.driverIsInstalled("test-driver-only-pre", false)
 }
 
@@ -373,7 +373,7 @@ func (suite *SubcommandTestSuite) TestInstallExplicitPrereleaseWithoutPreFlag() 
 	out := suite.runCmd(m)
 
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-only-pre 0.9.0-alpha.1 to "+suite.Dir()+"\n", out)
+		"\nInstalled test-driver-only-pre 0.9.0-alpha.1 to "+suite.Dir(), out)
 	suite.driverIsInstalled("test-driver-only-pre", false)
 }
 

--- a/cmd/dbc/registry_test.go
+++ b/cmd/dbc/registry_test.go
@@ -98,7 +98,7 @@ func (s *RegistryTestSuite) TestInstallDriver() {
 	m := InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	out := s.run(m)
-	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath+"\n", out)
+	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath, out)
 
 	k, err := registry.OpenKey(registry.CURRENT_USER, "SOFTWARE\\ADBC\\Drivers\\test-driver-1", registry.READ)
 	s.Require().NoError(err)
@@ -119,7 +119,7 @@ func (s *RegistryTestSuite) TestPartialReinstallDriver() {
 	m := InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	out := s.run(m)
-	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath+"\n", out)
+	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath, out)
 
 	s.clearRegistry()
 
@@ -127,7 +127,7 @@ func (s *RegistryTestSuite) TestPartialReinstallDriver() {
 	m = InstallCmd{Driver: "test-driver-1"}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 	out = s.run(m)
-	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath+"\n", out)
+	s.Equal("\nInstalled test-driver-1 1.1.0 to "+s.cfgUserPath, out)
 }
 
 func TestRegistryKeyHandling(t *testing.T) {

--- a/cmd/dbc/search.go
+++ b/cmd/dbc/search.go
@@ -339,7 +339,7 @@ func (m searchModel) FinalOutput() string {
 	if !m.outputJson && m.registryErrors != nil && len(m.finalDrivers) > 0 {
 		warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
 		output += "\n" + warningStyle.Render("Warning: ") + "Some driver registries were unavailable:\n"
-		output += m.registryErrors.Error() + "\n"
+		output += m.registryErrors.Error()
 	}
 
 	return output

--- a/cmd/dbc/uninstall.go
+++ b/cmd/dbc/uninstall.go
@@ -70,7 +70,7 @@ func (m uninstallModel) FinalOutput() string {
 	if m.jsonOutput {
 		return fmt.Sprintf("{\"status\": \"success\", \"driver\": \"%s\"}\n", m.Driver)
 	}
-	return fmt.Sprintf("Driver `%s` uninstalled successfully!\n", m.Driver)
+	return fmt.Sprintf("Driver `%s` uninstalled successfully!", m.Driver)
 }
 
 func (m uninstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/cmd/dbc/uninstall_test.go
+++ b/cmd/dbc/uninstall_test.go
@@ -50,7 +50,7 @@ version = "1.0.0"
 	os.WriteFile(path.Join(suite.tempdir, "found.toml"), []byte(contents), 0644)
 
 	m := UninstallCmd{Driver: "found", Level: config.ConfigEnv}.GetModel()
-	suite.validateOutput("\r ", "Driver `found` uninstalled successfully!\n", suite.runCmd(m))
+	suite.validateOutput("\r ", "Driver `found` uninstalled successfully!", suite.runCmd(m))
 }
 
 func (suite *SubcommandTestSuite) TestUninstallDriverAndManifest() {
@@ -72,7 +72,7 @@ version = "1.0.0"
 	os.WriteFile(path.Join(pkgdir, "some.dll"), []byte("anything"), 0o644)
 
 	m := UninstallCmd{Driver: "found", Level: config.ConfigEnv}.GetModel()
-	suite.validateOutput("\r ", "Driver `found` uninstalled successfully!\n", suite.runCmd(m))
+	suite.validateOutput("\r ", "Driver `found` uninstalled successfully!", suite.runCmd(m))
 }
 
 // Test what happens when a user installs a driver in multiple locations
@@ -169,8 +169,8 @@ func (suite *SubcommandTestSuite) TestUninstallManifestOnlyDriver() {
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
 
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-manifest-only 1.0.0 to "+suite.Dir()+"\n"+
-			"\nMust have libtest_driver installed to load this driver\n", suite.runCmd(m))
+		"\nInstalled test-driver-manifest-only 1.0.0 to "+suite.Dir()+
+			"\n\nMust have libtest_driver installed to load this driver", suite.runCmd(m))
 	suite.driverIsInstalled("test-driver-manifest-only", false)
 
 	// Verify the sidecar folder exists before we uninstall
@@ -184,7 +184,7 @@ func (suite *SubcommandTestSuite) TestUninstallManifestOnlyDriver() {
 	// Now uninstall and verify we clean up
 	m = UninstallCmd{Driver: "test-driver-manifest-only", Level: suite.configLevel}.
 		GetModelCustom(baseModel{getDriverRegistry: getTestDriverRegistry, downloadPkg: downloadTestPkg})
-	suite.validateOutput("\r ", "Driver `test-driver-manifest-only` uninstalled successfully!\n", suite.runCmd(m))
+	suite.validateOutput("\r ", "Driver `test-driver-manifest-only` uninstalled successfully!", suite.runCmd(m))
 	suite.driverIsNotInstalled("test-driver-manifest-only")
 	suite.NoDirExists(filepath.Join(suite.Dir(), new_sidecar_path))
 }
@@ -224,7 +224,7 @@ func (suite *SubcommandTestSuite) TestUninstallInvalidManifest() {
 	m = UninstallCmd{Driver: "test-driver-invalid-manifest", Level: suite.configLevel}.GetModel()
 	output := suite.runCmd(m)
 
-	suite.validateOutput("\r ", "Driver `test-driver-invalid-manifest` uninstalled successfully!\n", output)
+	suite.validateOutput("\r ", "Driver `test-driver-invalid-manifest` uninstalled successfully!", output)
 
 	// Ensure we don't nuke the installation directory which is the original (major) issue
 	suite.DirExists(suite.Dir())


### PR DESCRIPTION
A number of subcommands (install, uninstall, search, info, and docs) had extra newlines trailing their final output which led to the user seeing multiple blank lines of output at the end of each subcommand's output rather than one.

This PR normalizes all subcommands so they always have just one blank line at the end of their output.