### PR TITLE
feat: dbc auth license install

### DIFF
--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -262,9 +262,53 @@ func IsColumnarPrivateRegistry(u *url.URL) bool {
 }
 
 var (
-	ErrNoTrialLicense = errors.New("no trial license found")
-	ErrTrialExpired   = errors.New("trial license has expired")
+	ErrNoTrialLicense       = errors.New("no trial license found")
+	ErrTrialExpired         = errors.New("trial license has expired")
+	ErrLicenseWrongFilename = errors.New("source file is not named columnar.lic (use --force to override)")
+	ErrLicenseAlreadyExists = errors.New("license already exists (use --force to overwrite)")
 )
+
+func LicensePath() string {
+	return filepath.Join(filepath.Dir(credPath), "columnar.lic")
+}
+
+func InstallLicenseFromFile(srcPath string, force bool) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("failed to read license file: %w", err)
+	}
+	defer src.Close()
+
+	if !force && filepath.Base(srcPath) != "columnar.lic" {
+		return ErrLicenseWrongFilename
+	}
+
+	destPath := LicensePath()
+
+	if !force {
+		if _, err := os.Stat(destPath); err == nil {
+			return ErrLicenseAlreadyExists
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+		return fmt.Errorf("failed to create credentials directory: %w", err)
+	}
+
+	dst, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to write license file: %w", err)
+	}
+	defer dst.Close()
+
+	if _, err := dst.ReadFrom(src); err != nil {
+		dst.Close()
+		os.Remove(destPath)
+		return fmt.Errorf("failed to write license file: %w", err)
+	}
+
+	return nil
+}
 
 func FetchColumnarLicense(cred *Credential) error {
 	licensePath := filepath.Join(filepath.Dir(credPath), "columnar.lic")

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -273,12 +273,6 @@ func LicensePath() string {
 }
 
 func InstallLicenseFromFile(srcPath string, force bool) error {
-	src, err := os.Open(srcPath)
-	if err != nil {
-		return fmt.Errorf("failed to read license file: %w", err)
-	}
-	defer src.Close()
-
 	if !force && filepath.Base(srcPath) != "columnar.lic" {
 		return ErrLicenseWrongFilename
 	}
@@ -291,19 +285,16 @@ func InstallLicenseFromFile(srcPath string, force bool) error {
 		}
 	}
 
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return fmt.Errorf("failed to read license file: %w", err)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
 		return fmt.Errorf("failed to create credentials directory: %w", err)
 	}
 
-	dst, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o600)
-	if err != nil {
-		return fmt.Errorf("failed to write license file: %w", err)
-	}
-	defer dst.Close()
-
-	if _, err := dst.ReadFrom(src); err != nil {
-		dst.Close()
-		os.Remove(destPath)
+	if err := os.WriteFile(destPath, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write license file: %w", err)
 	}
 

--- a/cmd/dbc/auth.go
+++ b/cmd/dbc/auth.go
@@ -33,8 +33,18 @@ import (
 )
 
 type AuthCmd struct {
-	Login  *LoginCmd  `arg:"subcommand" help:"Authenticate with a driver registry"`
-	Logout *LogoutCmd `arg:"subcommand" help:"Log out from a driver registry"`
+	Login   *LoginCmd   `arg:"subcommand" help:"Authenticate with a driver registry"`
+	Logout  *LogoutCmd  `arg:"subcommand" help:"Log out from a driver registry"`
+	License *LicenseCmd `arg:"subcommand" help:"Manage license files"`
+}
+
+type LicenseCmd struct {
+	Install *LicenseInstallCmd `arg:"subcommand" help:"Install a license file"`
+}
+
+type LicenseInstallCmd struct {
+	LicensePath string `arg:"positional,required" help:"Path to the license file to install"`
+	Force       bool   `arg:"--force" help:"Overwrite existing license and skip filename check"`
 }
 
 type LoginCmd struct {
@@ -306,3 +316,60 @@ func (m logoutModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m logoutModel) View() tea.View { return tea.NewView("") }
+
+func (l LicenseInstallCmd) GetModelCustom(baseModel baseModel) tea.Model {
+	return licenseInstallModel{
+		baseModel:   baseModel,
+		licensePath: l.LicensePath,
+		force:       l.Force,
+	}
+}
+
+func (l LicenseInstallCmd) GetModel() tea.Model {
+	return l.GetModelCustom(
+		baseModel{
+			getDriverRegistry: getDriverRegistry,
+			downloadPkg:       downloadPkg,
+		},
+	)
+}
+
+type licenseInstalledMsg struct{}
+
+type licenseInstallModel struct {
+	baseModel
+
+	licensePath string
+	force       bool
+	installed   bool
+}
+
+func (m licenseInstallModel) Init() tea.Cmd {
+	return func() tea.Msg {
+		if err := auth.InstallLicenseFromFile(m.licensePath, m.force); err != nil {
+			return err
+		}
+		return licenseInstalledMsg{}
+	}
+}
+
+func (m licenseInstallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case licenseInstalledMsg:
+		m.installed = true
+		return m, tea.Quit
+	}
+
+	base, cmd := m.baseModel.Update(msg)
+	m.baseModel = base.(baseModel)
+	return m, cmd
+}
+
+func (m licenseInstallModel) FinalOutput() string {
+	if !m.installed {
+		return ""
+	}
+	return "License installed to " + auth.LicensePath()
+}
+
+func (m licenseInstallModel) View() tea.View { return tea.NewView("") }

--- a/cmd/dbc/auth_test.go
+++ b/cmd/dbc/auth_test.go
@@ -328,3 +328,177 @@ func (suite *SubcommandTestSuite) TestLogoutCmdInvalidURL() {
 	// The error will occur when trying to remove credentials
 	suite.Contains(out, "Error:")
 }
+
+func (suite *SubcommandTestSuite) TestLicenseInstallFileNotFound() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	cmd := LicenseInstallCmd{LicensePath: "/nonexistent/columnar.lic"}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "failed to read license file")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallWrongFilename() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "creds", "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	// Create a source file with wrong name
+	srcFile := filepath.Join(tmpDir, "my-license.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "--force")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallWrongFilenameWithForce() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "creds", "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	srcFile := filepath.Join(tmpDir, "my-license.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile, Force: true}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmd(m)
+	suite.Contains(out, "License installed")
+
+	installed, err := os.ReadFile(auth.LicensePath())
+	suite.Require().NoError(err)
+	suite.Equal("license-data", string(installed))
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallAlreadyExists() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	// Create existing license at destination
+	suite.Require().NoError(os.WriteFile(filepath.Join(tmpDir, "columnar.lic"), []byte("old"), 0o600))
+
+	// Create source file
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("new"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "--force")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallAlreadyExistsWithForce() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	// Create existing license at destination
+	suite.Require().NoError(os.WriteFile(filepath.Join(tmpDir, "columnar.lic"), []byte("old"), 0o600))
+
+	// Create source file
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("new"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile, Force: true}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmd(m)
+	suite.Contains(out, "License installed")
+
+	installed, err := os.ReadFile(auth.LicensePath())
+	suite.Require().NoError(err)
+	suite.Equal("new", string(installed))
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallUnreadableSource() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	// Create source file with no read permissions
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o000))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "failed to read license file")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallUnwritableTarget() {
+	tmpDir := suite.T().TempDir()
+	// Point credPath into an unwritable directory
+	unwritableDir := filepath.Join(tmpDir, "readonly")
+	suite.Require().NoError(os.MkdirAll(unwritableDir, 0o500))
+	credPath := filepath.Join(unwritableDir, "nested", "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile, Force: true}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "failed to create credentials directory")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallHappyPath() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmd(m)
+	suite.Contains(out, "License installed")
+
+	installed, err := os.ReadFile(auth.LicensePath())
+	suite.Require().NoError(err)
+	suite.Equal("license-data", string(installed))
+}

--- a/cmd/dbc/auth_test.go
+++ b/cmd/dbc/auth_test.go
@@ -438,48 +438,6 @@ func (suite *SubcommandTestSuite) TestLicenseInstallAlreadyExistsWithForce() {
 	suite.Equal("new", string(installed))
 }
 
-func (suite *SubcommandTestSuite) TestLicenseInstallUnreadableSource() {
-	tmpDir := suite.T().TempDir()
-	credPath := filepath.Join(tmpDir, "credentials.toml")
-	restore := auth.SetCredPathForTesting(credPath)
-	defer restore()
-
-	// Create source file with no read permissions
-	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
-	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o000))
-
-	cmd := LicenseInstallCmd{LicensePath: srcFile}
-	m := cmd.GetModelCustom(baseModel{
-		getDriverRegistry: getTestDriverRegistry,
-		downloadPkg:       downloadTestPkg,
-	})
-
-	out := suite.runCmdErr(m)
-	suite.Contains(out, "failed to read license file")
-}
-
-func (suite *SubcommandTestSuite) TestLicenseInstallUnwritableTarget() {
-	tmpDir := suite.T().TempDir()
-	// Point credPath into an unwritable directory
-	unwritableDir := filepath.Join(tmpDir, "readonly")
-	suite.Require().NoError(os.MkdirAll(unwritableDir, 0o500))
-	credPath := filepath.Join(unwritableDir, "nested", "credentials.toml")
-	restore := auth.SetCredPathForTesting(credPath)
-	defer restore()
-
-	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
-	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
-
-	cmd := LicenseInstallCmd{LicensePath: srcFile, Force: true}
-	m := cmd.GetModelCustom(baseModel{
-		getDriverRegistry: getTestDriverRegistry,
-		downloadPkg:       downloadTestPkg,
-	})
-
-	out := suite.runCmdErr(m)
-	suite.Contains(out, "failed to create credentials directory")
-}
-
 func (suite *SubcommandTestSuite) TestLicenseInstallHappyPath() {
 	tmpDir := suite.T().TempDir()
 	credPath := filepath.Join(tmpDir, "credentials.toml")

--- a/cmd/dbc/auth_unix_test.go
+++ b/cmd/dbc/auth_unix_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Columnar Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/columnar-tech/dbc/auth"
+)
+
+func (suite *SubcommandTestSuite) TestLicenseInstallUnreadableSource() {
+	tmpDir := suite.T().TempDir()
+	credPath := filepath.Join(tmpDir, "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	// Create source file with no read permissions
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o000))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "failed to read license file")
+}
+
+func (suite *SubcommandTestSuite) TestLicenseInstallUnwritableTarget() {
+	tmpDir := suite.T().TempDir()
+	// Point credPath into an unwritable directory
+	unwritableDir := filepath.Join(tmpDir, "readonly")
+	suite.Require().NoError(os.MkdirAll(unwritableDir, 0o500))
+	credPath := filepath.Join(unwritableDir, "nested", "credentials.toml")
+	restore := auth.SetCredPathForTesting(credPath)
+	defer restore()
+
+	srcFile := filepath.Join(suite.T().TempDir(), "columnar.lic")
+	suite.Require().NoError(os.WriteFile(srcFile, []byte("license-data"), 0o600))
+
+	cmd := LicenseInstallCmd{LicensePath: srcFile, Force: true}
+	m := cmd.GetModelCustom(baseModel{
+		getDriverRegistry: getTestDriverRegistry,
+		downloadPkg:       downloadTestPkg,
+	})
+
+	out := suite.runCmdErr(m)
+	suite.Contains(out, "failed to create credentials directory")
+}

--- a/cmd/dbc/auth_unix_test.go
+++ b/cmd/dbc/auth_unix_test.go
@@ -21,9 +21,14 @@ import (
 	"path/filepath"
 
 	"github.com/columnar-tech/dbc/auth"
+	"github.com/columnar-tech/dbc/config"
 )
 
 func (suite *SubcommandTestSuite) TestLicenseInstallUnreadableSource() {
+	if suite.configLevel == config.ConfigSystem {
+		suite.T().Skip("file permission tests are not effective when running as root")
+	}
+
 	tmpDir := suite.T().TempDir()
 	credPath := filepath.Join(tmpDir, "credentials.toml")
 	restore := auth.SetCredPathForTesting(credPath)
@@ -44,6 +49,10 @@ func (suite *SubcommandTestSuite) TestLicenseInstallUnreadableSource() {
 }
 
 func (suite *SubcommandTestSuite) TestLicenseInstallUnwritableTarget() {
+	if suite.configLevel == config.ConfigSystem {
+		suite.T().Skip("file permission tests are not effective when running as root")
+	}
+
 	tmpDir := suite.T().TempDir()
 	// Point credPath into an unwritable directory
 	unwritableDir := filepath.Join(tmpDir, "readonly")

--- a/cmd/dbc/completions/dbc.bash
+++ b/cmd/dbc/completions/dbc.bash
@@ -270,7 +270,7 @@ _dbc_auth_completions() {
         if [[ "$cur" == -* ]]; then
             COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
         else
-            COMPREPLY=($(compgen -W "login logout" -- "$cur"))
+            COMPREPLY=($(compgen -W "login logout license" -- "$cur"))
         fi
         return 0
     fi
@@ -284,6 +284,9 @@ _dbc_auth_completions() {
             ;;
         logout)
             _dbc_auth_logout_completions
+            ;;
+        license)
+            _dbc_auth_license_completions
             ;;
         *)
             COMPREPLY=()
@@ -325,6 +328,50 @@ _dbc_auth_logout_completions() {
 
     # Registry URL completion (no specific completion available)
     COMPREPLY=()
+}
+
+_dbc_auth_license_completions() {
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # If we're at position 3 (right after "license"), suggest subcommands
+    if [[ $COMP_CWORD -eq 3 ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W "install" -- "$cur"))
+        fi
+        return 0
+    fi
+
+    local license_subcommand="${COMP_WORDS[3]}"
+
+    case "$license_subcommand" in
+        install)
+            _dbc_auth_license_install_completions
+            ;;
+        *)
+            COMPREPLY=()
+            ;;
+    esac
+}
+
+_dbc_auth_license_install_completions() {
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "-h --help --force" -- "$cur"))
+        return 0
+    fi
+
+    # Complete .lic files
+    COMPREPLY=($(compgen -f -X '!*.lic' -- "$cur"))
+    if [[ -d "$cur" ]]; then
+        COMPREPLY+=($(compgen -d -- "$cur"))
+    fi
 }
 
 # Register the completion function

--- a/cmd/dbc/completions/dbc.fish
+++ b/cmd/dbc/completions/dbc.fish
@@ -126,6 +126,7 @@ complete -f -c dbc -n '__fish_dbc_using_subcommand auth' -s h -d 'Help'
 complete -f -c dbc -n '__fish_dbc_using_subcommand auth' -l help -d 'Help'
 complete -f -c dbc -n '__fish_dbc_auth_needs_subcommand' -a 'login' -d 'Authenticate with a driver registry'
 complete -f -c dbc -n '__fish_dbc_auth_needs_subcommand' -a 'logout' -d 'Log out from a driver registry'
+complete -f -c dbc -n '__fish_dbc_auth_needs_subcommand' -a 'license' -d 'Manage license files'
 
 # auth login subcommand
 complete -f -c dbc -n '__fish_dbc_auth_using_subcommand login' -s h -d 'Help'
@@ -136,3 +137,36 @@ complete -f -c dbc -n '__fish_dbc_auth_using_subcommand login' -l api-key -d 'Au
 complete -f -c dbc -n '__fish_dbc_auth_using_subcommand logout' -s h -d 'Help'
 complete -f -c dbc -n '__fish_dbc_auth_using_subcommand logout' -l help -d 'Help'
 complete -f -c dbc -n '__fish_dbc_auth_using_subcommand logout' -l purge -d 'Remove all local auth credentials for dbc'
+
+# Helper function to check if we need a license subcommand
+function __fish_dbc_auth_license_needs_subcommand
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -eq 3
+        if test $cmd[2] = "auth" -a $cmd[3] = "license"
+            return 0
+        end
+    end
+    return 1
+end
+
+# Helper function to check if we're using a specific auth license subcommand
+function __fish_dbc_auth_license_using_subcommand
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -gt 3
+        if test $cmd[2] = "auth" -a $cmd[3] = "license" -a $argv[1] = $cmd[4]
+            return 0
+        end
+    end
+    return 1
+end
+
+# auth license subcommand
+complete -f -c dbc -n '__fish_dbc_auth_using_subcommand license' -s h -d 'Help'
+complete -f -c dbc -n '__fish_dbc_auth_using_subcommand license' -l help -d 'Help'
+complete -f -c dbc -n '__fish_dbc_auth_license_needs_subcommand' -a 'install' -d 'Install a license file'
+
+# auth license install subcommand
+complete -f -c dbc -n '__fish_dbc_auth_license_using_subcommand install' -s h -d 'Help'
+complete -f -c dbc -n '__fish_dbc_auth_license_using_subcommand install' -l help -d 'Help'
+complete -f -c dbc -n '__fish_dbc_auth_license_using_subcommand install' -l force -d 'Overwrite existing license and skip filename check'
+complete -c dbc -n '__fish_dbc_auth_license_using_subcommand install' -F -a '*.lic' -d 'License file to install'

--- a/cmd/dbc/completions/dbc.zsh
+++ b/cmd/dbc/completions/dbc.zsh
@@ -173,7 +173,8 @@ function _dbc_auth_completions {
         auth_subcommand)
             _values "auth subcommand" \
                 'login[Authenticate with a driver registry]' \
-                'logout[Log out from a driver registry]'
+                'logout[Log out from a driver registry]' \
+                'license[Manage license files]'
         ;;
         auth_args)
             case $line[1] in
@@ -182,6 +183,9 @@ function _dbc_auth_completions {
                 ;;
                 logout)
                     _dbc_auth_logout_completions
+                ;;
+                license)
+                    _dbc_auth_license_completions
                 ;;
             esac
         ;;
@@ -202,6 +206,38 @@ function _dbc_auth_logout_completions {
         '(-h)--help[Help]' \
         '--purge[Remove all local auth credentials for dbc]' \
         ':registry URL: '
+}
+
+function _dbc_auth_license_completions {
+    local line state
+
+    _arguments -C \
+        '(--help)-h[Help]' \
+        '(-h)--help[Help]' \
+        "1: :->license_subcommand" \
+        "*::arg:->license_args"
+
+    case $state in
+        license_subcommand)
+            _values "license subcommand" \
+                'install[Install a license file]'
+        ;;
+        license_args)
+            case $line[1] in
+                install)
+                    _dbc_auth_license_install_completions
+                ;;
+            esac
+        ;;
+    esac
+}
+
+function _dbc_auth_license_install_completions {
+    _arguments \
+        '(--help)-h[Help]' \
+        '(-h)--help[Help]' \
+        '--force[Overwrite existing license and skip filename check]' \
+        ':license file:_files -g \*.lic'
 }
 
 # don't run the completion function when being source-d or eval-d

--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -241,6 +241,9 @@ func main() {
 	case *AuthCmd:
 		p.WriteHelpForSubcommand(os.Stdout, p.SubcommandNames()...)
 		os.Exit(2)
+	case *LicenseCmd:
+		p.WriteHelpForSubcommand(os.Stdout, p.SubcommandNames()...)
+		os.Exit(2)
 	case *completions.Cmd: // "dbc completions" without specifying the shell type
 		p.WriteHelpForSubcommand(os.Stdout, p.SubcommandNames()...)
 		os.Exit(2)

--- a/docs/guides/private_drivers.md
+++ b/docs/guides/private_drivers.md
@@ -54,7 +54,13 @@ dbc will automatically download your license if you:
 1. Have an active license
 2. Run `dbc install` with a private driver
 
-If you'd prefer to download the license manually, you can click **Download License File** and place the downloaded file in the appropriate location for your operating system:
+If you'd prefer to install the license manually, click **Download License File** on the Licenses page, then run:
+
+```console
+$ dbc auth license install /path/to/columnar.lic
+```
+
+This installs the license to the correct location for your operating system automatically. Alternatively, you can place the downloaded file directly in the appropriate location for your operating system:
 
 - Windows: `%LocalAppData%/dbc/credentials`
 - macOS:  `~/Library/Application Support/Columnar/dbc/credentials`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -328,6 +328,7 @@ $ dbc docs <DRIVER>
 ```console
 $ dbc auth login
 $ dbc auth logout
+$ dbc auth license install
 ```
 
 <h3>Subcommands</h3>
@@ -367,3 +368,23 @@ $ dbc auth logout
     !!! warning
 
         ADBC drivers that require a license (i.e., private drivers) will stop working after you run this command. You can re-download your license with `dbc auth login`. See [Downloading Your License](../guides/private_drivers.md#downloading-your-license).
+
+### license
+
+<h3>Subcommands</h3>
+
+#### install
+
+Install a license file to the dbc credentials directory.
+
+<h3>Arguments</h3>
+
+`LICENSEPATH`
+
+:   Path to the license file to install.
+
+<h3>Options</h3>
+
+`--force`
+
+:   Overwrite an existing license and skip the filename check.


### PR DESCRIPTION
I think we could make the steps in https://docs.columnar.tech/dbc/guides/private_drivers/#downloading-your-license even simpler if dbc handled putting your license in the right place for the user. This PR is a proposal for adding a `dbc auth license install` sub-subcommand to handle this. I tucked it under `dbc auth`.