### PR TITLE
docs: revert docs changes for dbc auth license install

### DIFF
--- a/docs/guides/private_drivers.md
+++ b/docs/guides/private_drivers.md
@@ -54,13 +54,7 @@ dbc will automatically download your license if you:
 1. Have an active license
 2. Run `dbc install` with a private driver
 
-If you'd prefer to install the license manually, click **Download License File** on the Licenses page, then run:
-
-```console
-$ dbc auth license install /path/to/columnar.lic
-```
-
-This installs the license to the correct location for your operating system automatically. Alternatively, you can place the downloaded file directly in the appropriate location for your operating system:
+If you'd prefer to download the license manually, you can click **Download License File** and place the downloaded file in the appropriate location for your operating system:
 
 - Windows: `%LocalAppData%/dbc/credentials`
 - macOS:  `~/Library/Application Support/Columnar/dbc/credentials`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -328,7 +328,6 @@ $ dbc docs <DRIVER>
 ```console
 $ dbc auth login
 $ dbc auth logout
-$ dbc auth license install
 ```
 
 <h3>Subcommands</h3>
@@ -368,23 +367,3 @@ $ dbc auth license install
     !!! warning
 
         ADBC drivers that require a license (i.e., private drivers) will stop working after you run this command. You can re-download your license with `dbc auth login`. See [Downloading Your License](../guides/private_drivers.md#downloading-your-license).
-
-### license
-
-<h3>Subcommands</h3>
-
-#### install
-
-Install a license file to the dbc credentials directory.
-
-<h3>Arguments</h3>
-
-`LICENSEPATH`
-
-:   Path to the license file to install.
-
-<h3>Options</h3>
-
-`--force`
-
-:   Overwrite an existing license and skip the filename check.


### PR DESCRIPTION
I should have pulled the docs change in https://github.com/columnar-tech/dbc/pull/352 out into a separate PR so we can merge just the docs changes once the next version of dbc is released. This PR reverts just the docs changes in that PR.