### PR TITLE
fix: include valid values in --level error message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,8 @@ func (c ConfigLevel) String() string {
 	}
 }
 
+var validLevelArgConfigValues = []ConfigLevel{ConfigUser, ConfigSystem}
+
 func (c *ConfigLevel) UnmarshalText(b []byte) error {
 	switch strings.ToLower(strings.TrimSpace(string(b))) {
 	case "system":
@@ -106,7 +108,11 @@ func (c *ConfigLevel) UnmarshalText(b []byte) error {
 	case "user":
 		*c = ConfigUser
 	default:
-		return errors.New("unknown config level")
+		names := make([]string, len(validLevelArgConfigValues))
+		for i, lvl := range validLevelArgConfigValues {
+			names[i] = lvl.String()
+		}
+		return fmt.Errorf("unknown config level %q, valid values are: %s", string(b), strings.Join(names, ", "))
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConfigLevelUnmarshalText(t *testing.T) {
+	valid := []struct {
+		input string
+		want  ConfigLevel
+	}{
+		{"user", ConfigUser},
+		{"system", ConfigSystem},
+		{"USER", ConfigUser},
+		{"SYSTEM", ConfigSystem},
+	}
+	for _, tt := range valid {
+		var c ConfigLevel
+		assert.NoError(t, c.UnmarshalText([]byte(tt.input)))
+		assert.Equal(t, tt.want, c)
+	}
+
+	invalid := []string{"env", "bad", ""}
+	for _, s := range invalid {
+		var c ConfigLevel
+		err := c.UnmarshalText([]byte(s))
+		assert.ErrorContains(t, err, "unknown config level")
+		assert.ErrorContains(t, err, "valid values are: user, system")
+	}
+}
+
 func TestConfigEnvVarHierarchy(t *testing.T) {
 	// Test the order is honored (ADBC_DRIVER_PATH before VIRTUAL_ENV before
 	// CONDA_PREFIX) and unset each one (in order) to verify.


### PR DESCRIPTION
Before:
```
error: error processing --level: unknown config level
```

After:
```
error: error processing --level: unknown config level "badvalue", valid values are: user, system
```