### PR TITLE
fix(docs): show docs url when opening a browser fails

### DIFF
--- a/cmd/dbc/docs.go
+++ b/cmd/dbc/docs.go
@@ -42,9 +42,9 @@ var openBrowserFunc = browser.OpenURL
 
 type docsUrlFound string
 
-type browserOpenFailed struct {
-	err error
-}
+type browserOpenFailed string
+
+func (e browserOpenFailed) Error() string { return string(e) }
 
 type DocsCmd struct {
 	Driver string `arg:"positional" help:"Driver to open documentation for"`
@@ -101,7 +101,7 @@ func (m docsModel) Init() tea.Cmd {
 func (m docsModel) openBrowserCmd(url string) tea.Cmd {
 	return func() tea.Msg {
 		if err := m.openBrowser(url); err != nil {
-			return browserOpenFailed{err: err}
+			return browserOpenFailed(err.Error())
 		}
 		return tea.Quit()
 	}
@@ -144,7 +144,7 @@ func (m docsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.openBrowserCmd(m.urlToOpen)
 
 	case browserOpenFailed:
-		m.browserOpenError = msg.err
+		m.browserOpenError = error(msg)
 		return m, tea.Quit
 	default:
 		bm, cmd := m.baseModel.Update(msg)

--- a/cmd/dbc/docs.go
+++ b/cmd/dbc/docs.go
@@ -42,6 +42,10 @@ var openBrowserFunc = browser.OpenURL
 
 type docsUrlFound string
 
+type browserOpenFailed struct {
+	err error
+}
+
 type DocsCmd struct {
 	Driver string `arg:"positional" help:"Driver to open documentation for"`
 	NoOpen bool   `arg:"--no-open" help:"Print the documentation URL instead of opening it in a web browser"`
@@ -64,12 +68,13 @@ func (c DocsCmd) GetModel() tea.Model {
 type docsModel struct {
 	baseModel
 
-	driver       string
-	drv          *dbc.Driver
-	urlToOpen    string
-	noOpen       bool
-	fallbackUrls map[string]string
-	openBrowser  func(string) error
+	driver           string
+	drv              *dbc.Driver
+	urlToOpen        string
+	browserOpenError error
+	noOpen           bool
+	fallbackUrls     map[string]string
+	openBrowser      func(string) error
 }
 
 func (m docsModel) Init() tea.Cmd {
@@ -96,7 +101,7 @@ func (m docsModel) Init() tea.Cmd {
 func (m docsModel) openBrowserCmd(url string) tea.Cmd {
 	return func() tea.Msg {
 		if err := m.openBrowser(url); err != nil {
-			return fmt.Errorf("failed to open browser: %w", err)
+			return browserOpenFailed{err: err}
 		}
 		return tea.Quit()
 	}
@@ -137,6 +142,10 @@ func (m docsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		return m, m.openBrowserCmd(m.urlToOpen)
+
+	case browserOpenFailed:
+		m.browserOpenError = msg.err
+		return m, tea.Quit
 	default:
 		bm, cmd := m.baseModel.Update(msg)
 		m.baseModel = bm.(baseModel)
@@ -149,14 +158,21 @@ func (m docsModel) View() tea.View {
 }
 
 func (m docsModel) FinalOutput() string {
-	if m.noOpen && m.urlToOpen != "" {
+	if (m.noOpen || m.browserOpenError != nil) && m.urlToOpen != "" {
 		var docName string
 		if m.driver == "" {
 			docName = "dbc"
 		} else {
 			docName = m.driver + " driver"
 		}
-		return fmt.Sprintf("%s docs are available at the following URL:\n%s", docName, m.urlToOpen)
+		urlMsg := fmt.Sprintf("%s docs are available at the following URL:\n%s", docName, m.urlToOpen)
+
+		// Prepend the error to the output if we have one
+		if m.browserOpenError != nil {
+			return fmt.Sprintf("Opening the %s docs automatically failed with error: %s\n\n%s", docName, m.browserOpenError, urlMsg)
+		}
+
+		return urlMsg
 	}
 	return ""
 }

--- a/cmd/dbc/docs_test.go
+++ b/cmd/dbc/docs_test.go
@@ -141,9 +141,9 @@ func (suite *SubcommandTestSuite) TestDocsBrowserOpenError() {
 		mockOpenBrowserError,
 		testFallbackUrls,
 	)
-	output := suite.runCmdErr(m)
+	output := suite.runCmd(m)
 
-	suite.Contains(output, "failed to open browser: browser not available")
+	suite.Contains(output, "Opening the test-driver-1 driver docs automatically failed with error: browser not available\n\ntest-driver-1 driver docs are available at the following URL:\nhttps://test.example.com/driver1")
 }
 
 func (suite *SubcommandTestSuite) TestDocsDriverFoundWithDocs() {


### PR DESCRIPTION
When someone uses dbc docs in a restricted environment such as GitHub Codespaces or a minimal docker container, the command can fail with an error like,

> Error: failed to open browser: exec: "xdg-open,x-www-browser,www-browser,wslview": executable file not found in $PATH

This PR catches any error and prints the URL for the user to open, essentially replicating the behavior of `--no-open` but with the addition of showing the error as well.

Closes #364 