### PR TITLE
fix: regroup subcommands

### DIFF
--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -166,16 +166,16 @@ func (m baseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 type cmds struct {
+	Search     *SearchCmd       `arg:"subcommand" help:"Search for a driver"`
 	Install    *InstallCmd      `arg:"subcommand" help:"Install a driver"`
 	Uninstall  *UninstallCmd    `arg:"subcommand" help:"Uninstall a driver"`
 	List       *ListCmd         `arg:"subcommand" help:"List installed drivers"`
-	Init       *InitCmd         `arg:"subcommand" help:"Initialize a new dbc driver list"`
-	Add        *AddCmd          `arg:"subcommand" help:"Add a driver to the driver list"`
-	Sync       *SyncCmd         `arg:"subcommand" help:"Sync installed drivers with drivers in the driver list"`
-	Search     *SearchCmd       `arg:"subcommand" help:"Search for a driver"`
 	Info       *InfoCmd         `arg:"subcommand" help:"Get information about a driver"`
 	Docs       *DocsCmd         `arg:"subcommand" help:"Open driver documentation in a web browser"`
+	Init       *InitCmd         `arg:"subcommand" help:"Initialize a new dbc driver list"`
+	Add        *AddCmd          `arg:"subcommand" help:"Add a driver to the driver list"`
 	Remove     *RemoveCmd       `arg:"subcommand" help:"Remove a driver from the driver list"`
+	Sync       *SyncCmd         `arg:"subcommand" help:"Sync installed drivers with drivers in the driver list"`
 	Auth       *AuthCmd         `arg:"subcommand" help:"Manage driver registry credentials"`
 	Completion *completions.Cmd `arg:"subcommand,hidden"`
 	Quiet      bool             `arg:"-q,--quiet" help:"Suppress all output"`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,12 +41,12 @@ $ dbc [OPTIONS] <COMMAND>
 <dt><a href="#install">dbc install</a></dt><dd><p>Install a driver</p></dd>
 <dt><a href="#uninstall">dbc uninstall</a></dt><dd><p>Uninstall a driver</p></dd>
 <dt><a href="#list">dbc list</a></dt><dd><p>List installed drivers</p></dd>
+<dt><a href="#info">dbc info</a></dt><dd><p>Get information about a driver</p></dd>
+<dt><a href="#docs">dbc docs</a></dt><dd><p>Open driver documentation in a web browser</p></dd>
 <dt><a href="#init">dbc init</a></dt><dd><p>Create a <a href="../../concepts/driver_list/">driver list</a> file</p></dd>
 <dt><a href="#add">dbc add</a></dt><dd><p>Add a driver to the <a href="../../concepts/driver_list/">driver list</a></p></dd>
 <dt><a href="#remove">dbc remove</a></dt><dd><p>Remove a driver from the <a href="../../concepts/driver_list/">driver list</a></p></dd>
 <dt><a href="#sync">dbc sync</a></dt><dd><p>Install the drivers from the <a href="../../concepts/driver_list/">driver list</a></p></dd>
-<dt><a href="#info">dbc info</a></dt><dd><p>Get information about a driver</p></dd>
-<dt><a href="#docs">dbc docs</a></dt><dd><p>Open driver documentation in a web browser</p></dd>
 <dt><a href="#auth">dbc auth</a></dt><dd><p>Manage driver registry credentials</p></dd>
 </dl>
 


### PR DESCRIPTION
Closes https://github.com/columnar-tech/dbc/issues/218

This re-groups our subcommands,

1. So the CLI and the CLI docs match in terms of order
2. So the subcommands are logically grouped

The groups are,

1. Search
2. Install/Uninstall/List
3. Info/Docs
4. Init/Add/Remove/Sync
5. Auth