### PR TITLE
feat: thread context through Client request methods

### DIFF
--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -77,10 +77,10 @@ type Credential struct {
 	Audience     string `toml:"audience,omitempty"`
 }
 
-func (t *Credential) Refresh() error {
+func (t *Credential) Refresh(ctx context.Context) error {
 	switch t.Type {
 	case TypeApiKey:
-		req, err := http.NewRequestWithContext(context.Background(),
+		req, err := http.NewRequestWithContext(ctx,
 			http.MethodGet, (*url.URL)(&t.AuthURI).String(), nil)
 		if err != nil {
 			return fmt.Errorf("apikey refresh: %w", err)
@@ -106,7 +106,7 @@ func (t *Credential) Refresh() error {
 		t.Token = tokenResp.Token
 		return nil
 	case TypeToken:
-		if err := refreshOauth(t); err != nil {
+		if err := refreshOauth(ctx, t); err != nil {
 			return fmt.Errorf("oauth refresh: %w", err)
 		}
 		return nil
@@ -117,12 +117,12 @@ func (t *Credential) Refresh() error {
 
 // GetAuthToken returns the current token, refreshing if needed.
 // Must not be called while credMu is held (Refresh may acquire it via UpdateCreds).
-func (t *Credential) GetAuthToken() string {
+func (t *Credential) GetAuthToken(ctx context.Context) string {
 	if t.Token != "" {
 		return t.Token
 	}
 
-	if err := t.Refresh(); err == nil {
+	if err := t.Refresh(ctx); err == nil {
 		_ = UpdateCreds()
 		return t.Token
 	}
@@ -356,7 +356,7 @@ func InstallLicenseFromFile(srcPath string, force bool) error {
 	return nil
 }
 
-func FetchColumnarLicense(cred *Credential) error {
+func FetchColumnarLicense(ctx context.Context, cred *Credential) error {
 	cp, err := getCredPath()
 	if err != nil {
 		return fmt.Errorf("failed to get credential path: %w", err)
@@ -378,7 +378,7 @@ func FetchColumnarLicense(cred *Credential) error {
 		authToken = cred.ApiKey
 	case TypeToken:
 		p := jwt.NewParser()
-		tk, err := p.Parse(cred.GetAuthToken(), nil)
+		tk, err := p.Parse(cred.GetAuthToken(ctx), nil)
 		if err != nil && !errors.Is(err, jwt.ErrTokenUnverifiable) {
 			return fmt.Errorf("failed to parse oauth token: %w", err)
 		}
@@ -387,12 +387,12 @@ func FetchColumnarLicense(cred *Credential) error {
 		if !ok {
 			return ErrNoTrialLicense
 		}
-		authToken = cred.GetAuthToken()
+		authToken = cred.GetAuthToken(ctx)
 	default:
 		return fmt.Errorf("unsupported credential type: %s", cred.Type)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, licenseURI, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, licenseURI, nil)
 	if err != nil {
 		return err
 	}

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -125,7 +125,7 @@ func TestCredential_GetAuthToken(t *testing.T) {
 		cred := &Credential{
 			Token: "existing-token",
 		}
-		assert.Equal(t, "existing-token", cred.GetAuthToken())
+		assert.Equal(t, "existing-token", cred.GetAuthToken(t.Context()))
 	})
 
 	t.Run("returns empty string when refresh fails", func(t *testing.T) {
@@ -143,7 +143,7 @@ func TestCredential_GetAuthToken(t *testing.T) {
 		}
 		cred.AuthURI = Uri(url.URL{Scheme: "http", Host: "invalid-host-xyz-123.local"})
 
-		token := cred.GetAuthToken()
+		token := cred.GetAuthToken(t.Context())
 		assert.Equal(t, "", token)
 	})
 }
@@ -165,7 +165,7 @@ func TestCredential_Refresh_ApiKey(t *testing.T) {
 			ApiKey:  "test-api-key",
 		}
 
-		err := cred.Refresh()
+		err := cred.Refresh(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, "new-token", cred.Token)
 	})
@@ -183,7 +183,7 @@ func TestCredential_Refresh_ApiKey(t *testing.T) {
 			ApiKey:  "invalid-key",
 		}
 
-		err := cred.Refresh()
+		err := cred.Refresh(t.Context())
 		assert.Error(t, err)
 	})
 
@@ -201,7 +201,7 @@ func TestCredential_Refresh_ApiKey(t *testing.T) {
 			ApiKey:  "test-api-key",
 		}
 
-		err := cred.Refresh()
+		err := cred.Refresh(t.Context())
 		assert.Error(t, err)
 	})
 }

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -60,8 +60,12 @@ type OpenIDConfig struct {
 	RequestParameterSupported         bool     `json:"request_parameter_supported"`
 }
 
-func fetch[T any](u *url.URL, dest *T) error {
-	resp, err := http.Get(u.String())
+func fetch[T any](ctx context.Context, u *url.URL, dest *T) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -74,11 +78,11 @@ func fetch[T any](u *url.URL, dest *T) error {
 	return json.NewDecoder(resp.Body).Decode(dest)
 }
 
-func GetOpenIDConfig(issuer *url.URL) (config OpenIDConfig, err error) {
+func GetOpenIDConfig(ctx context.Context, issuer *url.URL) (config OpenIDConfig, err error) {
 	for _, p := range []string{"openid-configuration", "oauth-authorization-server"} {
 		u, _ := issuer.Parse("/.well-known/" + p)
 
-		err = fetch(u, &config)
+		err = fetch(ctx, u, &config)
 		if err == nil {
 			return
 		}
@@ -87,8 +91,8 @@ func GetOpenIDConfig(issuer *url.URL) (config OpenIDConfig, err error) {
 	return config, err
 }
 
-func refreshOauth(cred *Credential) error {
-	cfg, err := GetOpenIDConfig((*url.URL)(&cred.AuthURI))
+func refreshOauth(ctx context.Context, cred *Credential) error {
+	cfg, err := GetOpenIDConfig(ctx, (*url.URL)(&cred.AuthURI))
 	if err != nil {
 		return err
 	}
@@ -100,7 +104,7 @@ func refreshOauth(cred *Credential) error {
 	}
 
 	payload := values.Encode()
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, cfg.TokenEndpoint.String(),
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenEndpoint.String(),
 		strings.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to build token request: %w", err)

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -53,7 +53,7 @@ func TestGetOpenIDConfig(t *testing.T) {
 		defer server.Close()
 
 		issuerURL, _ := url.Parse(server.URL)
-		config, err := GetOpenIDConfig(issuerURL)
+		config, err := GetOpenIDConfig(t.Context(), issuerURL)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com", config.Issuer.String())
@@ -89,7 +89,7 @@ func TestGetOpenIDConfig(t *testing.T) {
 		defer server.Close()
 
 		issuerURL, _ := url.Parse(server.URL)
-		config, err := GetOpenIDConfig(issuerURL)
+		config, err := GetOpenIDConfig(t.Context(), issuerURL)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com", config.Issuer.String())
@@ -104,7 +104,7 @@ func TestGetOpenIDConfig(t *testing.T) {
 		defer server.Close()
 
 		issuerURL, _ := url.Parse(server.URL)
-		_, err := GetOpenIDConfig(issuerURL)
+		_, err := GetOpenIDConfig(t.Context(), issuerURL)
 		assert.Error(t, err)
 	})
 
@@ -116,7 +116,7 @@ func TestGetOpenIDConfig(t *testing.T) {
 		defer server.Close()
 
 		issuerURL, _ := url.Parse(server.URL)
-		_, err := GetOpenIDConfig(issuerURL)
+		_, err := GetOpenIDConfig(t.Context(), issuerURL)
 		assert.Error(t, err)
 	})
 }
@@ -179,7 +179,7 @@ func TestRefreshOauth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := refreshOauth(cred)
+		err := refreshOauth(t.Context(), cred)
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", cred.Token)
 	})
@@ -192,7 +192,7 @@ func TestRefreshOauth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := refreshOauth(cred)
+		err := refreshOauth(t.Context(), cred)
 		assert.Error(t, err)
 	})
 
@@ -224,7 +224,7 @@ func TestRefreshOauth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := refreshOauth(cred)
+		err := refreshOauth(t.Context(), cred)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "token endpoint returned status")
 	})
@@ -271,7 +271,7 @@ func TestRefreshOauth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := refreshOauth(cred)
+		err := refreshOauth(t.Context(), cred)
 		assert.Error(t, err)
 	})
 }
@@ -307,7 +307,7 @@ func TestCredential_Refresh_OAuth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := cred.Refresh()
+		err := cred.Refresh(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, "refreshed-token", cred.Token)
 	})
@@ -321,7 +321,7 @@ func TestCredential_Refresh_OAuth(t *testing.T) {
 			RefreshToken: "test-refresh-token",
 		}
 
-		err := cred.Refresh()
+		err := cred.Refresh(t.Context())
 		assert.Error(t, err)
 	})
 }
@@ -336,7 +336,7 @@ func TestFetch(t *testing.T) {
 
 		serverURL, _ := url.Parse(server.URL)
 		var result map[string]string
-		err := fetch(serverURL, &result)
+		err := fetch(t.Context(), serverURL, &result)
 		require.NoError(t, err)
 		assert.Equal(t, "value", result["key"])
 	})
@@ -349,7 +349,7 @@ func TestFetch(t *testing.T) {
 
 		serverURL, _ := url.Parse(server.URL)
 		var result map[string]string
-		err := fetch(serverURL, &result)
+		err := fetch(t.Context(), serverURL, &result)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch")
 	})
@@ -363,14 +363,14 @@ func TestFetch(t *testing.T) {
 
 		serverURL, _ := url.Parse(server.URL)
 		var result map[string]string
-		err := fetch(serverURL, &result)
+		err := fetch(t.Context(), serverURL, &result)
 		assert.Error(t, err)
 	})
 
 	t.Run("return error on connection failure", func(t *testing.T) {
 		u, _ := url.Parse("http://invalid-host-xyz-123.local")
 		var result map[string]string
-		err := fetch(u, &result)
+		err := fetch(t.Context(), u, &result)
 		assert.Error(t, err)
 	})
 }

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -56,7 +56,7 @@ func TestClientWithCredential(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _ = c.Search("")
+	_, _ = c.Search(t.Context(), "")
 
 	assert.Equal(t, "Bearer "+token, gotAuthHeader)
 }
@@ -82,7 +82,7 @@ func TestClientWithAuthFromFilesystem(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _ = c.Search("")
+	_, _ = c.Search(t.Context(), "")
 
 	assert.Empty(t, gotAuthHeader)
 }

--- a/client_methods.go
+++ b/client_methods.go
@@ -32,7 +32,7 @@ import (
 	"github.com/go-faster/yaml"
 )
 
-func (c *Client) makeRequest(u string) (*http.Response, error) {
+func (c *Client) makeRequest(ctx context.Context, u string) (*http.Response, error) {
 	c.setup()
 
 	uri, err := url.Parse(u)
@@ -51,7 +51,7 @@ func (c *Client) makeRequest(u string) (*http.Response, error) {
 	uri.RawQuery = q.Encode()
 
 	buildReq := func(token string) (*http.Request, error) {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, uri.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -109,8 +109,8 @@ func (c *Client) makeRequest(u string) (*http.Response, error) {
 	return resp, nil
 }
 
-func (c *Client) getDriverListFromIndex(index *Registry) ([]Driver, error) {
-	resp, err := c.makeRequest(index.BaseURL.JoinPath("/index.yaml").String())
+func (c *Client) getDriverListFromIndex(ctx context.Context, index *Registry) ([]Driver, error) {
+	resp, err := c.makeRequest(ctx, index.BaseURL.JoinPath("/index.yaml").String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch drivers: %w", err)
 	}
@@ -147,14 +147,14 @@ func (c *Client) getDriverListFromIndex(index *Registry) ([]Driver, error) {
 }
 
 // Search searches for drivers matching the given pattern across all registries.
-func (c *Client) Search(pattern string) ([]Driver, error) {
+func (c *Client) Search(ctx context.Context, pattern string) ([]Driver, error) {
 	var (
 		allDrivers []Driver
 		totalErr   error
 	)
 
 	for i := range c.registries {
-		drivers, err := c.getDriverListFromIndex(&c.registries[i])
+		drivers, err := c.getDriverListFromIndex(ctx, &c.registries[i])
 		if err != nil {
 			totalErr = errors.Join(totalErr, fmt.Errorf("registry %s: %w", c.registries[i].BaseURL, err))
 			continue
@@ -179,13 +179,13 @@ func (c *Client) Search(pattern string) ([]Driver, error) {
 	return filtered, totalErr
 }
 
-func (c *Client) downloadPackage(pkg PkgInfo) (*os.File, error) {
+func (c *Client) downloadPackage(ctx context.Context, pkg PkgInfo) (*os.File, error) {
 	if pkg.Path == nil {
 		return nil, fmt.Errorf("cannot download package for %s: no url set", pkg.Driver.Title)
 	}
 
 	location := pkg.Path.String()
-	rsp, err := c.makeRequest(location)
+	rsp, err := c.makeRequest(ctx, location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download driver: %w", err)
 	}
@@ -227,11 +227,11 @@ func (c *Client) downloadPackage(pkg PkgInfo) (*os.File, error) {
 // io.ReadCloser. The caller is responsible for closing the returned body.
 // Auth credentials are resolved and injected automatically, including token
 // refresh on 401.
-func (c *Client) Download(pkg PkgInfo) (io.ReadCloser, error) {
+func (c *Client) Download(ctx context.Context, pkg PkgInfo) (io.ReadCloser, error) {
 	if pkg.Path == nil {
 		return nil, fmt.Errorf("cannot download package for %s: no url set", pkg.Driver.Title)
 	}
-	rsp, err := c.makeRequest(pkg.Path.String())
+	rsp, err := c.makeRequest(ctx, pkg.Path.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to download %s: %w", pkg.Path, err)
 	}
@@ -247,8 +247,8 @@ func (c *Client) Download(pkg PkgInfo) (io.ReadCloser, error) {
 }
 
 // Install installs a driver with the given name to the specified configuration.
-func (c *Client) Install(cfg config.Config, driverName string) (*config.Manifest, error) {
-	drivers, err := c.Search(driverName)
+func (c *Client) Install(ctx context.Context, cfg config.Config, driverName string) (*config.Manifest, error) {
+	drivers, err := c.Search(ctx, driverName)
 	// Only fail if the driver wasn't found in any registry; partial registry errors
 	// are acceptable as long as we can still locate the target driver.
 	if err != nil && len(drivers) == 0 {
@@ -272,7 +272,7 @@ func (c *Client) Install(cfg config.Config, driverName string) (*config.Manifest
 		return nil, fmt.Errorf("failed to get package for driver %s: %w", driverName, err)
 	}
 
-	f, err := c.downloadPackage(pkg)
+	f, err := c.downloadPackage(ctx, pkg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download driver %s: %w", driverName, err)
 	}

--- a/client_methods.go
+++ b/client_methods.go
@@ -67,9 +67,9 @@ func (c *Client) makeRequest(ctx context.Context, u string) (*http.Response, err
 	token := ""
 	if cred != nil {
 		if auth.IsColumnarPrivateRegistry(uri) {
-			_ = auth.FetchColumnarLicense(cred)
+			_ = auth.FetchColumnarLicense(ctx, cred)
 		}
-		token = cred.GetAuthToken()
+		token = cred.GetAuthToken(ctx)
 	}
 
 	req, err := buildReq(token)
@@ -83,10 +83,10 @@ func (c *Client) makeRequest(ctx context.Context, u string) (*http.Response, err
 
 	if resp.StatusCode == http.StatusUnauthorized && cred != nil {
 		resp.Body.Close()
-		if err := cred.Refresh(); err != nil {
+		if err := cred.Refresh(ctx); err != nil {
 			return nil, fmt.Errorf("failed to refresh auth token: %w", err)
 		}
-		req, err = buildReq(cred.GetAuthToken())
+		req, err = buildReq(cred.GetAuthToken(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to build retry request: %w", err)
 		}

--- a/client_methods_test.go
+++ b/client_methods_test.go
@@ -76,7 +76,7 @@ func TestClientSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty pattern returns all drivers", func(t *testing.T) {
-		drivers, err := c.Search("")
+		drivers, err := c.Search(t.Context(), "")
 		require.NoError(t, err)
 		assert.NotEmpty(t, drivers)
 
@@ -89,7 +89,7 @@ func TestClientSearch(t *testing.T) {
 	})
 
 	t.Run("pattern matches by path", func(t *testing.T) {
-		drivers, err := c.Search("test-driver-1")
+		drivers, err := c.Search(t.Context(), "test-driver-1")
 		require.NoError(t, err)
 		require.NotEmpty(t, drivers)
 
@@ -102,7 +102,7 @@ func TestClientSearch(t *testing.T) {
 	})
 
 	t.Run("nonexistent pattern returns empty list", func(t *testing.T) {
-		drivers, err := c.Search("nonexistent-driver-xyz")
+		drivers, err := c.Search(t.Context(), "nonexistent-driver-xyz")
 		require.NoError(t, err)
 		assert.Empty(t, drivers)
 	})
@@ -119,7 +119,7 @@ func TestClientInstall(t *testing.T) {
 	}
 
 	t.Run("installs driver successfully", func(t *testing.T) {
-		manifest, err := c.Install(cfg, "test-driver-1")
+		manifest, err := c.Install(t.Context(), cfg, "test-driver-1")
 		require.NoError(t, err)
 		require.NotNil(t, manifest)
 		assert.Equal(t, "test-driver-1", manifest.DriverInfo.ID)
@@ -127,7 +127,7 @@ func TestClientInstall(t *testing.T) {
 	})
 
 	t.Run("returns error for nonexistent driver", func(t *testing.T) {
-		_, err := c.Install(cfg, "nonexistent-driver")
+		_, err := c.Install(t.Context(), cfg, "nonexistent-driver")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent-driver")
 	})
@@ -144,7 +144,7 @@ func TestClientUninstall(t *testing.T) {
 			Location: tmpDir,
 		}
 
-		_, err := c.Install(cfg, "test-driver-1")
+		_, err := c.Install(t.Context(), cfg, "test-driver-1")
 		require.NoError(t, err)
 
 		manifestPath := filepath.Join(tmpDir, "test-driver-1.toml")
@@ -182,7 +182,7 @@ func TestClientDownload(t *testing.T) {
 			Driver: dbc.Driver{Title: "test-driver-1"},
 			Path:   pkgURL,
 		}
-		body, err := c.Download(pkg)
+		body, err := c.Download(t.Context(), pkg)
 		require.NoError(t, err)
 		defer body.Close()
 
@@ -195,7 +195,7 @@ func TestClientDownload(t *testing.T) {
 		pkg := dbc.PkgInfo{
 			Driver: dbc.Driver{Title: "nil-path-driver"},
 		}
-		_, err := c.Download(pkg)
+		_, err := c.Download(t.Context(), pkg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no url set")
 		assert.Contains(t, err.Error(), "nil-path-driver")
@@ -216,7 +216,7 @@ func TestClientDownload(t *testing.T) {
 			Driver: dbc.Driver{Title: "error-driver"},
 			Path:   pkgURL,
 		}
-		_, err = errClient.Download(pkg)
+		_, err = errClient.Download(t.Context(), pkg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "500")
 		assert.Contains(t, err.Error(), "package not found in storage backend")

--- a/cmd/dbc/auth.go
+++ b/cmd/dbc/auth.go
@@ -142,7 +142,7 @@ func (m loginModel) Init() tea.Cmd {
 
 func (m loginModel) authConfig() tea.Cmd {
 	return func() tea.Msg {
-		cfg, err := auth.GetOpenIDConfig(m.parsedURI)
+		cfg, err := auth.GetOpenIDConfig(context.TODO(), m.parsedURI)
 		if err != nil {
 			return fmt.Errorf("failed to get OpenID configuration: %w", err)
 		}
@@ -172,7 +172,7 @@ func (m loginModel) apiKeyToToken() tea.Cmd {
 			ApiKey:      m.apiKey,
 		}
 
-		if err := cred.Refresh(); err != nil {
+		if err := cred.Refresh(context.TODO()); err != nil {
 			return fmt.Errorf("failed to obtain access token using provided API key: %w", err)
 		}
 
@@ -244,7 +244,7 @@ func (m loginModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.storedCred = &msg.cred
 		return m, func() tea.Msg {
 			if auth.IsColumnarPrivateRegistry((*url.URL)(&msg.cred.RegistryURL)) {
-				if err := auth.FetchColumnarLicense(&msg.cred); err != nil {
+				if err := auth.FetchColumnarLicense(context.TODO(), &msg.cred); err != nil {
 					return err
 				}
 			}

--- a/cmd/dbc/main.go
+++ b/cmd/dbc/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -99,7 +100,7 @@ var getDriverRegistry = func() ([]dbc.Driver, error) {
 	if err := initDBCClient(); err != nil {
 		return nil, fmt.Errorf("failed to initialize client: %w", err)
 	}
-	return dbcClient.Search("")
+	return dbcClient.Search(context.Background(), "")
 }
 
 func findDriver(name string, drivers []dbc.Driver) (dbc.Driver, error) {

--- a/drivers.go
+++ b/drivers.go
@@ -186,9 +186,9 @@ func makereq(u string) (resp *http.Response, err error) {
 			// fetch the trial license. This will be a no-op if they have
 			// a license saved already, and if they haven't started their
 			// trial or it is expired, then this will silently fail.
-			_ = auth.FetchColumnarLicense(cred)
+			_ = auth.FetchColumnarLicense(context.Background(), cred)
 		}
-		token = cred.GetAuthToken()
+		token = cred.GetAuthToken(context.Background())
 	}
 
 	req, err := buildLegacyReq(token)
@@ -202,10 +202,10 @@ func makereq(u string) (resp *http.Response, err error) {
 
 	if resp.StatusCode == http.StatusUnauthorized && cred != nil {
 		resp.Body.Close()
-		if err := cred.Refresh(); err != nil {
+		if err := cred.Refresh(context.Background()); err != nil {
 			return nil, fmt.Errorf("failed to refresh auth token: %w", err)
 		}
-		retryReq, retryErr := buildLegacyReq(cred.GetAuthToken())
+		retryReq, retryErr := buildLegacyReq(cred.GetAuthToken(context.Background()))
 		if retryErr != nil {
 			return nil, fmt.Errorf("failed to build retry request: %w", retryErr)
 		}

--- a/drivers.go
+++ b/drivers.go
@@ -540,7 +540,7 @@ func GetDriverList() ([]Driver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.Search("")
+	return c.Search(context.Background(), "")
 }
 
 // Deprecated: Signature verification is now handled internally by Client.Install.


### PR DESCRIPTION
## Summary
- Accept `context.Context` on `dbc.Client` methods that issue HTTP requests (`Search`, `Download`, `Install`) and the internal helpers (`makeRequest`, `getDriverListFromIndex`, `downloadPackage`).
- `makeRequest` now threads the passed context into `http.NewRequestWithContext` rather than using `context.Background()`.
- `Uninstall` is unchanged — it makes no network calls.
- Existing callers (`drivers.GetDriverList`, `cmd/dbc/main.getDriverRegistry`, tests) pass `context.Background()` / `t.Context()`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`