### PR TITLE
feat(search): print message when no drivers are found

### DIFF
--- a/cmd/dbc/search.go
+++ b/cmd/dbc/search.go
@@ -344,6 +344,22 @@ func (m searchModel) FinalOutput() string {
 		output = viewDriversJSON(m.finalDrivers, m.verbose, m.pre, m.registryErrors)
 	} else {
 		output = viewDrivers(m.finalDrivers, m.verbose, m.pre)
+		if output == "" {
+			// Some matched drivers exist but all are pre-release and --pre wasn't passed.
+			if !m.pre && len(m.finalDrivers) > 0 {
+				var preCmd string
+				if m.pattern != nil {
+					preCmd = "dbc search --pre " + m.pattern.String()
+				} else {
+					preCmd = "dbc search --pre"
+				}
+				return fmt.Sprintf("Only one or more pre-release drivers matched your pattern `%s`. To include them, use: %s", m.pattern.String(), preCmd)
+			}
+			if m.pattern != nil {
+				return "No drivers matched your pattern `" + m.pattern.String() + "`."
+			}
+			return "No drivers found."
+		}
 	}
 
 	// Display warning about registry errors after the driver list (only if we have some drivers to show)

--- a/cmd/dbc/search_test.go
+++ b/cmd/dbc/search_test.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/columnar-tech/dbc"
@@ -413,4 +414,24 @@ func (suite *SubcommandTestSuite) TestSearch_JSON_CompleteRegistryFailure() {
 		baseModel{getDriverRegistry: completeFailingRegistry, downloadPkg: downloadTestPkg})
 	out := suite.runCmdErr(m)
 	suite.assertJSONErrorEnvelope(out, "search_failed")
+}
+
+func (suite *SubcommandTestSuite) TestSearchNoDriversEmptyRegistry() {
+	emptyRegistry := func() ([]dbc.Driver, error) { return nil, nil }
+	m := SearchCmd{}.GetModelCustom(
+		baseModel{getDriverRegistry: emptyRegistry, downloadPkg: downloadTestPkg})
+	out := suite.runCmd(m)
+	suite.Equal("No drivers found.", out)
+}
+
+func (suite *SubcommandTestSuite) TestSearchNoDriversPatternNotFound() {
+	m := SearchCmd{Pattern: regexp.MustCompile("no-such-driver")}.GetModelCustom(testBaseModel())
+	out := suite.runCmd(m)
+	suite.Equal("No drivers matched your pattern `no-such-driver`.", out)
+}
+
+func (suite *SubcommandTestSuite) TestSearchOnlyPreReleaseDriversFound() {
+	m := SearchCmd{Pattern: regexp.MustCompile("only-pre")}.GetModelCustom(testBaseModel())
+	out := suite.runCmd(m)
+	suite.Equal("Only one or more pre-release drivers matched your pattern `only-pre`. To include them, use: dbc search --pre only-pre", out)
 }


### PR DESCRIPTION
Adds a check to `dbc search` when no drivers are returned and prints a helpful message instead of nothing.

There are three cases to handle here,

1. registry is empty
2. search pattern doesn't match anything
3. search pattern only matches pre-release drivers

This change handles all of those.

Related, dbc list prints a message when no drivers are installed so we should do one or the other consistently. So this change makes search consistent with the new behavior we introduced with dbc list.

Closes https://github.com/columnar-tech/dbc/issues/376