### PR TITLE
ci(release): enable winget release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           DBC_TAP_GITHUB_PAT: ${{ secrets.DBC_TAP_GITHUB_PAT }}
+          DBC_WINGET_GITHUB_PAT: ${{ secrets.DBC_WINGET_GITHUB_PAT }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # 1.12.4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -333,6 +333,34 @@ homebrew_casks:
       token_type: "github"
       token: "{{ .Env.DBC_TAP_GITHUB_PAT }}" # we'll probably need a dedicated PAT or something?
 
+winget:
+  - name: dbc
+    publisher: Columnar
+    publisher_url: "https://columnar.tech/"
+    publisher_support_url: "https://github.com/columnar-tech/dbc/issues"
+    package_identifier: "Columnar.dbc"
+    short_description: "dbc is a command-line tool for installing and managing ADBC drivers."
+    description: "dbc is a command-line tool for installing and managing ADBC drivers."
+    homepage: "https://docs.columnar.tech/dbc/"
+    license: Apache-2.0
+    license_url: "https://github.com/columnar-tech/dbc/blob/HEAD/LICENSE"
+    release_notes_url: "https://github.com/columnar-tech/dbc/releases/tag/{{ .Tag }}"
+    tags:
+      - adbc
+      - apache
+      - apache-arrow
+      - cli
+      - database-connector
+      - open-source
+    skip_upload: auto
+    repository:
+      owner: columnar-tech
+      name: winget-pkgs
+      branch: "dbc-{{ .Version }}"
+      token: "{{ .Env.DBC_WINGET_GITHUB_PAT }}"
+      pull_request:
+        enabled: false
+
 release:
   ids:
     - archives


### PR DESCRIPTION
Since creating PR to the winget-pkgs repo is not automated, someone needs to do it.

Also, winget doesn't currently distinguish between pre-release and newer versions, so it might be better to skip creating PRs for pre-release versions.