### PR TITLE
docs: use fully qualified winget install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ powershell -ExecutionPolicy ByPass -c irm https://dbc.columnar.tech/install.ps1 
 ### WinGet
 
 ```
-winget install dbc
+winget install Columnar.dbc
 ```
 
 ### Windows MSI

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -131,7 +131,7 @@ You can also download the latest installer using the following URL:
 On Windows, you can install dbc using [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
 
 ```console
-$ winget install dbc
+$ winget install Columnar.dbc
 ```
 
 !!! note
@@ -140,7 +140,7 @@ $ winget install dbc
 
     ```console
     $ winget uninstall --id Columnar.dbc
-    $ winget install dbc
+    $ winget install Columnar.dbc
     ```
 
 ## Docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
 === "WinGet"
 
     ```console
-    $ winget install dbc
+    $ winget install Columnar.dbc
     ```
 
     !!! note
@@ -52,7 +52,7 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
 
         ```console
         $ winget uninstall --id Columnar.dbc
-        $ winget install dbc
+        $ winget install Columnar.dbc
         ```
 
 === "uv"


### PR DESCRIPTION
`winget install dbc` is no longer specific enough and users will get a list of options instead of winget just installing dbc. This replaces all the references with their fully-qualified equivalent.