### PR TITLE
test(install): cover downgrade by reinstalling an older version

### DIFF
--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -99,20 +99,20 @@ func (suite *SubcommandTestSuite) TestReinstallUpdateVersion() {
 }
 
 func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
-	m := InstallCmd{Driver: "test-driver-1"}.
+	m := InstallCmd{Driver: "test-driver-1", Level: suite.configLevel}.
 		GetModelCustom(testBaseModel())
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nInstalled test-driver-1 1.1.0 to "+suite.tempdir, suite.runCmd(m))
+		"\nInstalled test-driver-1 1.1.0 to "+suite.Dir(), suite.runCmd(m))
 	suite.driverIsInstalledWithVersion("test-driver-1", "1.1.0", true)
 
-	m = InstallCmd{Driver: "test-driver-1<=1.0.0"}.
+	m = InstallCmd{Driver: "test-driver-1<=1.0.0", Level: suite.configLevel}.
 		GetModelCustom(testBaseModel())
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
-		"\nRemoved conflicting driver: test-driver-1 (version: 1.1.0)\nInstalled test-driver-1 1.0.0 to "+suite.tempdir,
+		"\nRemoved conflicting driver: test-driver-1 (version: 1.1.0)\nInstalled test-driver-1 1.0.0 to "+suite.Dir(),
 		suite.runCmd(m))
 
 	suite.Equal([]string{"test-driver-1/test-driver-1-not-valid.so",
-		"test-driver-1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInTempDir())
+		"test-driver-1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInDir(suite.Dir()))
 	suite.driverIsInstalledWithVersion("test-driver-1", "1.0.0", true)
 }
 

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -98,6 +98,22 @@ func (suite *SubcommandTestSuite) TestReinstallUpdateVersion() {
 		"test-driver-1.1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInTempDir())
 }
 
+func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
+	m := InstallCmd{Driver: "test-driver-1"}.
+		GetModelCustom(testBaseModel())
+	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
+		"\nInstalled test-driver-1 1.1.0 to "+suite.tempdir, suite.runCmd(m))
+
+	m = InstallCmd{Driver: "test-driver-1<=1.0.0"}.
+		GetModelCustom(testBaseModel())
+	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
+		"\nRemoved conflicting driver: test-driver-1 (version: 1.1.0)\nInstalled test-driver-1 1.0.0 to "+suite.tempdir,
+		suite.runCmd(m))
+
+	suite.Equal([]string{"test-driver-1/test-driver-1-not-valid.so",
+		"test-driver-1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInTempDir())
+}
+
 func (suite *SubcommandTestSuite) TestInstallVenv() {
 	suite.T().Setenv("ADBC_DRIVER_PATH", "")
 	suite.T().Setenv("VIRTUAL_ENV", suite.tempdir)

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -99,10 +99,6 @@ func (suite *SubcommandTestSuite) TestReinstallUpdateVersion() {
 }
 
 func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
-	if runtime.GOOS == "windows" && (suite.configLevel == config.ConfigUser || suite.configLevel == config.ConfigSystem) {
-		suite.T().Skip("Driver manifest is stored in the registry on Windows for User and System config levels, so the file-list assertion does not apply")
-	}
-
 	m := InstallCmd{Driver: "test-driver-1", Level: suite.configLevel}.
 		GetModelCustom(testBaseModel())
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
@@ -115,8 +111,10 @@ func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
 		"\nRemoved conflicting driver: test-driver-1 (version: 1.1.0)\nInstalled test-driver-1 1.0.0 to "+suite.Dir(),
 		suite.runCmd(m))
 
-	suite.Equal([]string{"test-driver-1/test-driver-1-not-valid.so",
-		"test-driver-1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInDir(suite.Dir()))
+	files := suite.getFilesInDir(suite.Dir())
+	suite.Contains(files, "test-driver-1/test-driver-1-not-valid.so")
+	suite.Contains(files, "test-driver-1/test-driver-1-not-valid.so.sig")
+	suite.NotContains(files, "test-driver-1.1/test-driver-1-not-valid.so")
 	suite.driverIsInstalledWithVersion("test-driver-1", "1.0.0", true)
 }
 

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -99,6 +99,10 @@ func (suite *SubcommandTestSuite) TestReinstallUpdateVersion() {
 }
 
 func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
+	if runtime.GOOS == "windows" && (suite.configLevel == config.ConfigUser || suite.configLevel == config.ConfigSystem) {
+		suite.T().Skip("Driver manifest is stored in the registry on Windows for User and System config levels, so the file-list assertion does not apply")
+	}
+
 	m := InstallCmd{Driver: "test-driver-1", Level: suite.configLevel}.
 		GetModelCustom(testBaseModel())
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",

--- a/cmd/dbc/install_test.go
+++ b/cmd/dbc/install_test.go
@@ -103,6 +103,7 @@ func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
 		GetModelCustom(testBaseModel())
 	suite.validateOutput("\r[✓] searching\r\n[✓] downloading\r\n[✓] installing\r\n[✓] verifying signature\r\n",
 		"\nInstalled test-driver-1 1.1.0 to "+suite.tempdir, suite.runCmd(m))
+	suite.driverIsInstalledWithVersion("test-driver-1", "1.1.0", true)
 
 	m = InstallCmd{Driver: "test-driver-1<=1.0.0"}.
 		GetModelCustom(testBaseModel())
@@ -112,6 +113,7 @@ func (suite *SubcommandTestSuite) TestReinstallDowngradeVersion() {
 
 	suite.Equal([]string{"test-driver-1/test-driver-1-not-valid.so",
 		"test-driver-1/test-driver-1-not-valid.so.sig", "test-driver-1.toml"}, suite.getFilesInTempDir())
+	suite.driverIsInstalledWithVersion("test-driver-1", "1.0.0", true)
 }
 
 func (suite *SubcommandTestSuite) TestInstallVenv() {

--- a/cmd/dbc/subcommand_test.go
+++ b/cmd/dbc/subcommand_test.go
@@ -293,16 +293,28 @@ func (suite *SubcommandTestSuite) assertJSONErrorEnvelope(output, expectedCode s
 	}
 }
 
-func (suite *SubcommandTestSuite) driverIsInstalled(path string, checkShared bool) {
+func (suite *SubcommandTestSuite) getInstalledDriver(path string) config.DriverInfo {
 	cfg := config.Get()[suite.configLevel]
-
 	driver, err := config.GetDriver(cfg, path)
 	suite.Require().NoError(err, "driver manifest should exist for driver `%s`", path)
+	return driver
+}
 
+func (suite *SubcommandTestSuite) driverIsInstalled(path string, checkShared bool) {
+	driver := suite.getInstalledDriver(path)
 	if checkShared {
 		sharedPath := driver.Driver.Shared.Get(config.PlatformTuple())
 		suite.FileExists(sharedPath, "driver shared library should exist for driver `%s`", path)
 	}
+}
+
+func (suite *SubcommandTestSuite) driverIsInstalledWithVersion(path, version string, checkShared bool) {
+	driver := suite.getInstalledDriver(path)
+	if checkShared {
+		sharedPath := driver.Driver.Shared.Get(config.PlatformTuple())
+		suite.FileExists(sharedPath, "driver shared library should exist for driver `%s`", path)
+	}
+	suite.Equal(version, driver.Version.String(), "installed version of driver `%s` should be %s", path, version)
 }
 
 func (suite *SubcommandTestSuite) driverIsNotInstalled(path string) {

--- a/cmd/dbc/subcommand_test.go
+++ b/cmd/dbc/subcommand_test.go
@@ -122,8 +122,12 @@ func (suite *SubcommandTestSuite) TearDownSuite() {
 }
 
 func (suite *SubcommandTestSuite) getFilesInTempDir() []string {
+	return suite.getFilesInDir(suite.tempdir)
+}
+
+func (suite *SubcommandTestSuite) getFilesInDir(dir string) []string {
 	var filelist []string
-	suite.NoError(fs.WalkDir(os.DirFS(suite.tempdir), ".", func(path string, d fs.DirEntry, err error) error {
+	suite.NoError(fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
 		if d.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
## Summary

Adds `TestReinstallDowngradeVersion` to `cmd/dbc/install_test.go`, mirroring the existing `TestReinstallUpdateVersion` but exercising the opposite direction: install latest, then reinstall pinned to an older version.

Before this change, no test verified that downgrading a driver:

1. Removes the previously-installed newer version (including its install directory)
2. Lays down the older version's files on disk
3. Leaves the driver discoverable via the manifest

The conflict-and-replace path (`Removed conflicting driver: …`) was only covered for upgrades (1.0.0 → 1.1.0). This adds symmetric coverage for downgrades (1.1.0 → 1.0.0), exercising the same code path with the version comparison reversed.

## Test plan

```
$ go test -run 'TestSubcommandsEnv/TestReinstall(Update|Downgrade)Version' -v ./cmd/dbc/...
=== RUN   TestSubcommandsEnv/TestReinstallDowngradeVersion
=== RUN   TestSubcommandsEnv/TestReinstallUpdateVersion
--- PASS: TestSubcommandsEnv (0.01s)
    --- PASS: TestSubcommandsEnv/TestReinstallDowngradeVersion (0.01s)
    --- PASS: TestSubcommandsEnv/TestReinstallUpdateVersion (0.00s)
PASS
```

`go vet ./cmd/dbc/...` is clean.

## Notes

The expected install directory for v1.0.0 is `test-driver-1/` (not `test-driver-1.0/`) because the directory name is derived from the tarball filename (`test-driver-1.tar.gz` for v1.0.0, `test-driver-1.1.tar.gz` for v1.1.0) per `config.InstallDriver`. No fixture changes are needed.