### PR TITLE
fix(wasm): driver discovery on Windows hosts

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # windows-latest is intentionally excluded: the WASM Windows-host path is
-        # experimental and not yet passing (driver discovery under GOOS=js — see
-        # https://github.com/columnar-tech/dbc/issues/396). Re-add when fixed.
-        os: [ 'ubuntu-latest', 'macos-latest' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/config/config.go
+++ b/config/config.go
@@ -148,28 +148,6 @@ func EnsureLocation(cfg Config) (string, error) {
 	return loc, nil
 }
 
-func loadDir(dir string) (map[string]DriverInfo, error) {
-	if _, err := os.Stat(dir); err != nil {
-		return nil, err
-	}
-
-	ret := make(map[string]DriverInfo)
-
-	fsys := os.DirFS(dir)
-	matches, _ := fs.Glob(fsys, "*.toml")
-	for _, m := range matches {
-		p := filepath.Join(dir, m)
-		di, err := loadDriverFromManifest(filepath.Dir(p), filepath.Base(p))
-		if err != nil {
-			continue
-		}
-
-		di.FilePath = filepath.Dir(p)
-		ret[di.ID] = di
-	}
-	return ret, nil
-}
-
 func loadConfig(lvl ConfigLevel) Config {
 	cfg := Config{Level: lvl, Location: lvl.ConfigLocation()}
 	if cfg.Location == "" {

--- a/config/loaddir_js.go
+++ b/config/loaddir_js.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Columnar Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build js
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// loadDir lists installed drivers from a directory. Under GOOS=js, os.ReadDir
+// and os.DirFS fail on Windows hosts because Go's js/wasm syscall layer rejects
+// the O_DIRECTORY flag (Node.js does not expose it on Windows). We work around
+// this by using os.Open (which omits O_DIRECTORY) followed by File.ReadDir.
+func loadDir(dir string) (map[string]DriverInfo, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := f.ReadDir(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[string]DriverInfo)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		di, err := loadDriverFromManifest(filepath.Dir(p), filepath.Base(p))
+		if err != nil {
+			continue
+		}
+		di.FilePath = filepath.Dir(p)
+		ret[di.ID] = di
+	}
+	return ret, nil
+}

--- a/config/loaddir_other.go
+++ b/config/loaddir_other.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Columnar Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !js
+
+package config
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func loadDir(dir string) (map[string]DriverInfo, error) {
+	if _, err := os.Stat(dir); err != nil {
+		return nil, err
+	}
+
+	ret := make(map[string]DriverInfo)
+
+	fsys := os.DirFS(dir)
+	matches, _ := fs.Glob(fsys, "*.toml")
+	for _, m := range matches {
+		p := filepath.Join(dir, m)
+		di, err := loadDriverFromManifest(filepath.Dir(p), filepath.Base(p))
+		if err != nil {
+			continue
+		}
+
+		di.FilePath = filepath.Dir(p)
+		ret[di.ID] = di
+	}
+	return ret, nil
+}


### PR DESCRIPTION
## Summary

- Fix `listInstalled` returning empty on Windows hosts when running via WASM. The root cause is Go's js/wasm `syscall.Open` rejecting `O_DIRECTORY` (Node.js doesn't expose `fs.constants.O_DIRECTORY` on Windows), which breaks `os.ReadDir`/`os.DirFS`/`fs.Glob`.
- Split `loadDir` into build-tagged files: `loaddir_js.go` uses `os.Open` + `File.ReadDir` (avoids `O_DIRECTORY`); `loaddir_other.go` keeps the original `os.DirFS` + `fs.Glob` path.
- Re-enable `windows-latest` in the WASM CI workflow.

Closes #396

## Test plan

- [x] `node packages/npm-wasm/test/smoke.cjs` passes on Windows (install + listInstalled + uninstall round-trip)
- [x] `node packages/npm-wasm/test/worker.test.cjs` passes on Windows
- [x] `go test ./config/...` passes natively on Windows
- [x] `go vet ./config/...` passes for both `GOOS=js` and native targets
- [x] CI passes on all three platforms (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)