### PR TITLE
ci: automatically sync dbc outputs in docs

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -18,6 +18,11 @@ on:
   schedule:
     - cron: "23 14 * * *"  # 14:23 UTC daily
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: sync docs but do not open a PR"
+        type: boolean
+        default: false
 
 concurrency:
   group: sync-docs
@@ -57,7 +62,7 @@ jobs:
           fi
 
       - name: Push branch and open PR
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_BODY: |

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -1,0 +1,86 @@
+# Copyright 2026 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Sync Docs
+
+on:
+  schedule:
+    - cron: "23 14 * * *"  # 14:23 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: sync-docs
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: true
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dbc
+        run: pip install dbc
+
+      - name: Run sync
+        run: python scripts/sync_docs.py
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push branch and open PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: |
+            Automated update of `dbc` command output in docs.
+
+            This PR was opened by the [Sync Docs](../actions/workflows/sync_docs.yml) workflow after detecting that one or more annotated output blocks no longer match the output of the currently released `dbc`.
+
+            **Review the diff before merging** to confirm the changes look correct and there are no unexpected formatting regressions.
+        run: |
+          BRANCH="docs/sync-output-$(date +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add docs/
+          git commit -m "docs: sync dbc command output"
+          git push --force origin "$BRANCH"
+
+          # Open a PR only if one doesn't already exist for this branch.
+          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --title "docs: sync dbc command output" \
+              --body "$PR_BODY" \
+              --head "$BRANCH" \
+              --base main \
+              --label "documentation"
+          fi

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -73,6 +73,7 @@ Let's use dbc to install the BigQuery ADBC driver.
 
 First, run `dbc search` to find the exact name of the driver:
 
+<!-- dbc-output: search -->
 ```console
 $ dbc search
 bigquery             An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
@@ -92,6 +93,7 @@ trino                An ADBC Driver for Trino developed by the ADBC Driver Found
 oracle     [private] An ADBC driver for Oracle Database developed by Columnar
 teradata   [private] An ADBC driver for Teradata developed by Columnar
 ```
+<!-- /dbc-output -->
 
 From the output, you can see that the name you'll need is `"bigquery"`.
 Now install it:

--- a/docs/guides/finding_drivers.md
+++ b/docs/guides/finding_drivers.md
@@ -18,6 +18,7 @@ limitations under the License.
 
 You can list the available drivers by running `dbc search`:
 
+<!-- dbc-output: search -->
 ```console
 $ dbc search
 bigquery             An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
@@ -37,6 +38,7 @@ trino                An ADBC Driver for Trino developed by the ADBC Driver Found
 oracle     [private] An ADBC driver for Oracle Database developed by Columnar
 teradata   [private] An ADBC driver for Teradata developed by Columnar
 ```
+<!-- /dbc-output -->
 
 !!! note
 

--- a/docs/guides/installing.md
+++ b/docs/guides/installing.md
@@ -23,6 +23,7 @@ But before you can install a driver, you need to know what drivers are available
 
 To find out what drivers are available, use `dbc search`:
 
+<!-- dbc-output: search -->
 ```console
 $ dbc search
 bigquery             An ADBC driver for Google BigQuery developed by the ADBC Driver Foundry
@@ -42,6 +43,7 @@ trino                An ADBC Driver for Trino developed by the ADBC Driver Found
 oracle     [private] An ADBC driver for Oracle Database developed by Columnar
 teradata   [private] An ADBC driver for Teradata developed by Columnar
 ```
+<!-- /dbc-output -->
 
 The short names in lowercase on the left of the output are the names you need to pass to `dbc install`.
 

--- a/scripts/sync_docs.py
+++ b/scripts/sync_docs.py
@@ -161,7 +161,7 @@ def main() -> int:
 
     if not shutil.which("dbc"):
         print(
-            "error: `dbc` not found in PATH — install with: pip install dbc",
+            "error: `dbc` not found in PATH — install with: uv tool install dbc",
             file=sys.stderr,
         )
         return 1

--- a/scripts/sync_docs.py
+++ b/scripts/sync_docs.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright 2026 Columnar Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sync dbc command output in documentation.
+
+Finds every block delimited by:
+
+    <!-- dbc-output: ARGS -->
+    ```console
+    $ dbc ARGS
+    <live output>
+    ```
+    <!-- /dbc-output -->
+
+markers in docs/ and replaces the block content by running `dbc ARGS` live.
+
+The script requires a clean environment — no drivers may be installed when it
+runs. This ensures that commands like `dbc search` reflect only what is
+available in the registry and are not affected by locally installed state.
+The script checks this upfront via `dbc list --json` and exits with an error
+if any drivers are found.
+
+Usage:
+    python scripts/sync_docs.py          # Update docs in-place
+    python scripts/sync_docs.py --check  # Exit 1 if any blocks are stale
+"""
+
+import argparse
+import json
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+# Matches a complete annotated block including its surrounding markers.
+BLOCK_RE = re.compile(
+    r"<!-- dbc-output: (?P<args>[^\n]+?) -->\n"
+    r"```console\n"
+    r"(?P<content>.*?)"
+    r"```\n"
+    r"<!-- /dbc-output -->",
+    re.DOTALL,
+)
+
+
+def check_clean_environment() -> str | None:
+    """
+    Return an error message if any drivers are installed, None if the
+    environment is clean.
+    """
+    result = subprocess.run(
+        ["dbc", "list", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return f"`dbc list --json` failed: {result.stderr.strip() or f'exited {result.returncode}'}"
+    data = json.loads(result.stdout)
+    drivers = data.get("payload", {}).get("drivers", [])
+    if drivers:
+        names = ", ".join(d["driver"] for d in drivers)
+        return (
+            f"found {len(drivers)} installed driver(s): {names}\n"
+            "Uninstall all drivers before running this script to avoid "
+            "polluting the output."
+        )
+    return None
+
+
+def run_dbc(args_str: str) -> str:
+    """Run `dbc ARGS` and return stdout. Raises RuntimeError on failure."""
+    args = shlex.split(args_str)
+    try:
+        result = subprocess.run(
+            ["dbc"] + args,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("`dbc` not found in PATH — install with: pip install dbc")
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"exited {result.returncode}")
+    return result.stdout
+
+
+def make_block(args_str: str, output: str) -> str:
+    """Build the full annotated block string from fresh command output."""
+    output = output.rstrip("\n") + "\n"
+    return (
+        f"<!-- dbc-output: {args_str} -->\n"
+        f"```console\n"
+        f"$ dbc {args_str}\n"
+        f"{output}"
+        f"```\n"
+        f"<!-- /dbc-output -->"
+    )
+
+
+def sync_file(path: Path, check: bool) -> tuple[bool, list[str]]:
+    """
+    Sync all annotated blocks in a single file.
+    Returns (changed, errors). When check=True the file is never written.
+    """
+    original = path.read_text(encoding="utf-8")
+    changed = False
+    errors: list[str] = []
+
+    def replacer(m: re.Match) -> str:
+        nonlocal changed
+        args_str = m.group("args")
+        try:
+            output = run_dbc(args_str)
+        except Exception as exc:
+            errors.append(f"{path.relative_to(REPO_ROOT)}: `dbc {args_str}`: {exc}")
+            return m.group(0)
+
+        new_block = make_block(args_str, output)
+        if new_block != m.group(0):
+            changed = True
+        return new_block
+
+    updated = BLOCK_RE.sub(replacer, original)
+
+    if changed and not check:
+        path.write_text(updated, encoding="utf-8")
+
+    return changed, errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any blocks are out of date (do not modify files)",
+    )
+    opts = parser.parse_args()
+
+    if not shutil.which("dbc"):
+        print(
+            "error: `dbc` not found in PATH — install with: pip install dbc",
+            file=sys.stderr,
+        )
+        return 1
+
+    env_error = check_clean_environment()
+    if env_error:
+        print(f"error: {env_error}", file=sys.stderr)
+        return 1
+
+    doc_files = sorted(DOCS_DIR.rglob("*.md"))
+    stale: list[Path] = []
+    all_errors: list[str] = []
+
+    for path in doc_files:
+        if "<!-- dbc-output:" not in path.read_text(encoding="utf-8"):
+            continue
+        changed, errors = sync_file(path, check=opts.check)
+        all_errors.extend(errors)
+        if changed:
+            stale.append(path)
+            verb = "stale" if opts.check else "updated"
+            print(f"{verb}: {path.relative_to(REPO_ROOT)}")
+
+    if all_errors:
+        for err in all_errors:
+            print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if opts.check and stale:
+        print(
+            f"\n{len(stale)} file(s) have stale dbc output. "
+            "Run `python scripts/sync_docs.py` to update.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not stale:
+        print("All annotated blocks are up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
PRs like https://github.com/columnar-tech/dbc/pull/401 that update our docs with outputs from live runs of dbc can be automated. This PR does that.

This PR adds a script that can check and update our docs and hooks that into daily CI that can create PRs with the diff. The script takes advantage of special comment fences so we'll need to be mindful of using those if we add more example output in the docs.