### PR TITLE
chore: skip release snapshot job on dependabot prs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     environment: snapshot
-    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
If you look at dependabot PRs like https://github.com/columnar-tech/dbc/pull/407 you see it fails because it can't get the PGP key,

```
Run echo "$COLUMNAR_GPG_KEY" | gpg --batch --import
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
Error: Process completed with exit code 2.
```

I'm assuming this is because dependabot PRs run with lower privs and don't have access to secrets/environments. So I think we should just skip the snapshot job on dependabot PRs.

Goes with https://github.com/columnar-tech/dbc/pull/409.