### PR TITLE
chore: bump go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ module github.com/columnar-tech/dbc
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.0.0


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.4 to 1.26.5.
