### PR TITLE
chore(ci): use go-version-file on all workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.25
+          go-version-file: "./go.mod"
           cache: true
           cache-dependency-path: go.sum
       - name: Build dbc

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.25
+          go-version-file: "./go.mod"
           cache: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.26
+          go-version-file: "./go.mod"
           cache: true
           cache-dependency-path: go.sum
       - name: Node version


### PR DESCRIPTION
We bumped the Go toolchain to 1.26 but still had hardcoded Go versions in a few of our CI workflows pinning to 1.25. This PR updates all workflows to use the `go-version-file` option so that all workflows rely on what's in go.mod.