### PR TITLE
docs: update brew install to trust columnar-tech tap

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -167,13 +167,8 @@ The following distroless images are available for Linux-based `amd64` and `arm64
 You can install dbc from our Homebrew tap by running:
 
 ```console
-$ brew install columnar-tech/tap/dbc
-```
-
-This will automatically configure our tap and install dbc from it. If you'd rather do this as two separate commands, you can run:
-
-```console
 $ brew tap columnar-tech/tap
+$ brew trust columnar-tech/tap
 $ brew install dbc
 ```
 


### PR DESCRIPTION
Updates the Homebrew install section in the install docs to document the install steps under with new [Tap Trust](https://docs.brew.sh/Tap-Trust) feature in Homebrew 6. Tap Trust means users can no longer automatically tap on install without trusting first so I've simplified the docs to show the series of commands users now need.