### PR TITLE
chore(ci): fix whitespace handling bug in sync_docs.py

### DIFF
--- a/scripts/sync_docs.py
+++ b/scripts/sync_docs.py
@@ -100,7 +100,7 @@ def run_dbc(args_str: str) -> str:
         raise RuntimeError("`dbc` not found in PATH — install with: pip install dbc")
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"exited {result.returncode}")
-    return result.stdout
+    return "\n".join(line.rstrip() for line in result.stdout.splitlines())
 
 
 def make_block(args_str: str, output: str) -> str:


### PR DESCRIPTION
sync_docs.py was preserving the whitespace that comes from bubbletea's output
copying output into the docs. This is fine but then none of our editors can
be set up to strip trailing whitespace.

This PR just strips the trailing whitespace on each line from stdout before
returning it.
