### PR TITLE
docs: update drivers and driver managers

### DIFF
--- a/docs/guides/driver_manager.md
+++ b/docs/guides/driver_manager.md
@@ -20,58 +20,6 @@ In order to use any of the drivers you [install](./installing.md) with dbc, you 
 
 The best place to find detailed information on driver manager installation is always the [ADBC docs](https://arrow.apache.org/adbc/) but we've included concise steps for a variety of languages here for convenience:
 
-=== "Python"
-
-    === "uv"
-
-        ```console
-        $ uv pip install adbc_driver_manager pyarrow
-        ```
-
-    === "pip"
-
-        ```console
-        $ pip install adbc_driver_manager pyarrow
-        ```
-
-    === "conda"
-
-        ```console
-        $ conda install -c conda-forge adbc-driver-manager pyarrow
-        ```
-
-=== "R"
-
-    ```r
-    install.packages("adbcdrivermanager")
-    ```
-
-=== "Go"
-
-    ```console
-    $ go get github.com/apache/arrow-adbc/go/adbc/drivermgr
-    ```
-
-=== "Ruby"
-
-    === "Bundler"
-
-        ```console
-        $ bundle add red-adbc
-        ```
-
-    === "gem"
-
-        ```console
-        $ gem install red-adbc
-        ```
-
-=== "Rust"
-
-    ```console
-    $ cargo add adbc_core adbc_driver_manager
-    ```
-
 === "C++"
 
     === "conda"
@@ -110,6 +58,12 @@ The best place to find detailed information on driver manager installation is al
         $ sudo dnf install adbc-driver-manager-devel
 
         ```
+
+=== "Go"
+
+    ```console
+    $ go get github.com/apache/arrow-adbc/go/adbc/drivermgr
+    ```
 
 === "Java"
 
@@ -153,3 +107,49 @@ The best place to find detailed information on driver manager installation is al
     ```
 
     Note that with the above you'll also need to set an `adbcVersion` property to an appropriate version.
+
+===+ "Python"
+
+    === "uv"
+
+        ```console
+        $ uv pip install adbc_driver_manager pyarrow
+        ```
+
+    === "pip"
+
+        ```console
+        $ pip install adbc_driver_manager pyarrow
+        ```
+
+    === "conda"
+
+        ```console
+        $ conda install -c conda-forge adbc-driver-manager pyarrow
+        ```
+
+=== "R"
+
+    ```r
+    install.packages("adbcdrivermanager")
+    ```
+
+=== "Ruby"
+
+    === "Bundler"
+
+        ```console
+        $ bundle add red-adbc
+        ```
+
+    === "gem"
+
+        ```console
+        $ gem install red-adbc
+        ```
+
+=== "Rust"
+
+    ```console
+    $ cargo add adbc_core adbc_driver_manager
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,7 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
 === "ClickHouse"
 
     ```console
-    $ dbc install --pre clickhouse
+    $ dbc install clickhouse
     ```
 
     <br/>3. [Install a driver manager](./guides/driver_manager.md) and load drivers in any supported language:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1222,7 +1222,7 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
 === "Spark"
 
     ```console
-    $ dbc install --pre spark
+    $ dbc install spark
     ```
 
     <br/>3. [Install a driver manager](./guides/driver_manager.md) and load drivers in any supported language:

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,6 +143,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("bigquery")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "bigquery")
+        ```
+
     === "Rust"
 
         ```rust
@@ -217,6 +225,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("clickhouse")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "clickhouse")
         ```
 
     === "Rust"
@@ -295,6 +311,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("databricks")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "databricks")
+        ```
+
     === "Rust"
 
         ```rust
@@ -369,6 +393,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("datafusion")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "datafusion")
         ```
 
     === "Rust"
@@ -447,6 +479,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("duckdb")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "duckdb")
+        ```
+
     === "Rust"
 
         ```rust
@@ -521,6 +561,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("exasol")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "exasol")
         ```
 
     === "Rust"
@@ -599,6 +647,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("flightsql")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "flightsql")
+        ```
+
     === "Rust"
 
         ```rust
@@ -675,6 +731,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("mssql")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "mssql")
+        ```
+
     === "Rust"
 
         ```rust
@@ -749,6 +813,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("mysql")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "mysql")
         ```
 
     === "Rust"
@@ -831,6 +903,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("oracle")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "oracle")
+        ```
+
     === "Rust"
 
         ```rust
@@ -905,6 +985,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("postgresql")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "postgresql")
         ```
 
     === "Rust"
@@ -983,6 +1071,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("quack")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "quack")
+        ```
+
     === "Rust"
 
         ```rust
@@ -1057,6 +1153,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("redshift")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "redshift")
         ```
 
     === "Rust"
@@ -1135,6 +1239,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("singlestore")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "singlestore")
+        ```
+
     === "Rust"
 
         ```rust
@@ -1209,6 +1321,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("snowflake")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "snowflake")
         ```
 
     === "Rust"
@@ -1287,6 +1407,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("spark")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "spark")
+        ```
+
     === "Rust"
 
         ```rust
@@ -1361,6 +1489,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("sqlite")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "sqlite")
         ```
 
     === "Rust"
@@ -1443,6 +1579,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         drv <- adbc_driver("teradata")
         ```
 
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "teradata")
+        ```
+
     === "Rust"
 
         ```rust
@@ -1517,6 +1661,14 @@ dbc is the command-line tool for installing and managing [ADBC](https://arrow.ap
         library(adbcdrivermanager)
 
         drv <- adbc_driver("trino")
+        ```
+
+    === "Ruby"
+
+        ```ruby
+        require "adbc"
+
+        database.set_option("driver", "trino")
         ```
 
     === "Rust"


### PR DESCRIPTION
- Removes `--pre` from the Spark and ClickHouse driver install commands on the index page
- Adds Ruby to the languages on the index page
- Alphabetizes the languages in the driver managers guide