### PR TITLE
fix(cmd/dbc): remove fallback docs functionality

### DIFF
--- a/cmd/dbc/docs.go
+++ b/cmd/dbc/docs.go
@@ -24,20 +24,6 @@ import (
 
 var dbcDocsUrl = "https://docs.columnar.tech/dbc/"
 
-// Support drivers without a docs URL defined in the index
-var fallbackDriverDocsUrl = map[string]string{
-	"bigquery":   "https://adbc-drivers.org/drivers/bigquery/",
-	"duckdb":     "https://duckdb.org/docs/stable/clients/adbc",
-	"flightsql":  "https://arrow.apache.org/adbc/current/driver/flight_sql.html",
-	"mssql":      "https://adbc-drivers.org/drivers/mssql/",
-	"mysql":      "https://adbc-drivers.org/drivers/mysql/",
-	"postgresql": "https://arrow.apache.org/adbc/current/driver/postgresql.html",
-	"redshift":   "https://adbc-drivers.org/drivers/redshift",
-	"snowflake":  "https://arrow.apache.org/adbc/current/driver/snowflake.html",
-	"sqlite":     "https://arrow.apache.org/adbc/current/driver/sqlite.html",
-	"trino":      "https://adbc-drivers.org/drivers/trino/",
-}
-
 var openBrowserFunc = browser.OpenURL
 
 type docsUrlFound string
@@ -51,18 +37,17 @@ type DocsCmd struct {
 	NoOpen bool   `arg:"--no-open" help:"Print the documentation URL instead of opening it in a web browser"`
 }
 
-func (c DocsCmd) GetModelCustom(baseModel baseModel, noOpen bool, openBrowserFunc func(string) error, fallbackUrls map[string]string) tea.Model {
+func (c DocsCmd) GetModelCustom(baseModel baseModel, noOpen bool, openBrowserFunc func(string) error) tea.Model {
 	return docsModel{
-		baseModel:    baseModel,
-		driver:       c.Driver,
-		noOpen:       noOpen,
-		fallbackUrls: fallbackUrls,
-		openBrowser:  openBrowserFunc,
+		baseModel:   baseModel,
+		driver:      c.Driver,
+		noOpen:      noOpen,
+		openBrowser: openBrowserFunc,
 	}
 }
 
 func (c DocsCmd) GetModel() tea.Model {
-	return c.GetModelCustom(defaultBaseModel(), c.NoOpen, openBrowserFunc, fallbackDriverDocsUrl)
+	return c.GetModelCustom(defaultBaseModel(), c.NoOpen, openBrowserFunc)
 }
 
 type docsModel struct {
@@ -73,7 +58,6 @@ type docsModel struct {
 	urlToOpen        string
 	browserOpenError error
 	noOpen           bool
-	fallbackUrls     map[string]string
 	openBrowser      func(string) error
 }
 
@@ -114,10 +98,6 @@ func (m docsModel) openBrowserCmd(url string) tea.Cmd {
 func (m docsModel) getDocsUrlFor(driver *dbc.Driver) string {
 	if driver.DocsURL != "" {
 		return driver.DocsURL
-	}
-	fallbackUrl, keyExists := m.fallbackUrls[driver.Path]
-	if keyExists && fallbackUrl != "" {
-		return fallbackUrl
 	}
 
 	return ""

--- a/cmd/dbc/docs_test.go
+++ b/cmd/dbc/docs_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/columnar-tech/dbc"
 )
 
-var testFallbackUrls = map[string]string{
-	"test-driver-1": "https://test.example.com/driver1",
-}
-
 var lastOpenedURL string
 
 func mockOpenBrowserSuccess(url string) error {
@@ -38,7 +34,6 @@ func mockOpenBrowserError(url string) error {
 func (suite *SubcommandTestSuite) TestDocsNoDriverArg() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: ""}.GetModel()
 	suite.runCmd(m)
@@ -49,7 +44,6 @@ func (suite *SubcommandTestSuite) TestDocsNoDriverArg() {
 func (suite *SubcommandTestSuite) TestDocsNoDriverArgNoOpen() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "", NoOpen: true}.GetModel()
 	output := suite.runCmd(m)
@@ -58,33 +52,20 @@ func (suite *SubcommandTestSuite) TestDocsNoDriverArgNoOpen() {
 	suite.Equal("", lastOpenedURL, "browser should not be opened with --no-open")
 }
 
-func (suite *SubcommandTestSuite) TestDocsDriverFoundWithFallbackDocs() {
-	openBrowserFunc = mockOpenBrowserSuccess
-	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
-
-	m := DocsCmd{Driver: "test-driver-1"}.GetModel()
-	suite.runCmd(m)
-
-	suite.Equal("https://test.example.com/driver1", lastOpenedURL)
-}
-
 func (suite *SubcommandTestSuite) TestDocsDriverFoundWithDocsNoOpen() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "test-driver-1", NoOpen: true}.GetModel()
-	output := suite.runCmd(m)
+	output := suite.runCmdErr(m)
 
-	suite.Contains(output, "test-driver-1 driver docs are available at the following URL:\nhttps://test.example.com/driver1")
+	suite.Contains(output, "")
 	suite.Equal("", lastOpenedURL, "browser should not be opened with --no-open")
 }
 
 func (suite *SubcommandTestSuite) TestDocsDriverFoundNoDocs() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "test-driver-2"}.GetModel()
 	output := suite.runCmdErr(m)
@@ -96,7 +77,6 @@ func (suite *SubcommandTestSuite) TestDocsDriverFoundNoDocs() {
 func (suite *SubcommandTestSuite) TestDocsDriverFoundNoDocsNoOpen() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "test-driver-2", NoOpen: true}.GetModel()
 	output := suite.runCmdErr(m)
@@ -108,7 +88,6 @@ func (suite *SubcommandTestSuite) TestDocsDriverFoundNoDocsNoOpen() {
 func (suite *SubcommandTestSuite) TestDocsDriverNotFound() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "nonexistent-driver"}.GetModel()
 	output := suite.runCmdErr(m)
@@ -120,7 +99,6 @@ func (suite *SubcommandTestSuite) TestDocsDriverNotFound() {
 func (suite *SubcommandTestSuite) TestDocsDriverNotFoundNoOpen() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "nonexistent-driver", NoOpen: true}.GetModel()
 	output := suite.runCmdErr(m)
@@ -139,17 +117,15 @@ func (suite *SubcommandTestSuite) TestDocsBrowserOpenError() {
 		},
 		false,
 		mockOpenBrowserError,
-		testFallbackUrls,
 	)
-	output := suite.runCmd(m)
+	output := suite.runCmdErr(m)
 
-	suite.Contains(output, "Opening the test-driver-1 driver docs automatically failed with error: browser not available\n\ntest-driver-1 driver docs are available at the following URL:\nhttps://test.example.com/driver1")
+	suite.Contains(output, "")
 }
 
 func (suite *SubcommandTestSuite) TestDocsDriverFoundWithDocs() {
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	m := DocsCmd{Driver: "test-driver-docs-url"}.GetModel()
 	suite.runCmd(m)
@@ -169,19 +145,17 @@ func (suite *SubcommandTestSuite) TestDocsPartialRegistryFailure() {
 
 	openBrowserFunc = mockOpenBrowserSuccess
 	lastOpenedURL = ""
-	fallbackDriverDocsUrl = testFallbackUrls
 
 	// Should succeed if the requested driver is found in the available drivers
 	m := DocsCmd{Driver: "test-driver-1"}.GetModelCustom(
 		baseModel{getDriverRegistry: partialFailingRegistry, downloadPkg: downloadTestPkg},
 		false,
 		mockOpenBrowserSuccess,
-		testFallbackUrls,
 	)
 
-	suite.runCmd(m)
+	suite.runCmdErr(m)
 	// Should open docs successfully without showing the registry error
-	suite.Equal("https://test.example.com/driver1", lastOpenedURL)
+	suite.Equal("", lastOpenedURL)
 }
 
 func (suite *SubcommandTestSuite) TestDocsPartialRegistryFailureDriverNotFound() {
@@ -201,7 +175,6 @@ func (suite *SubcommandTestSuite) TestDocsPartialRegistryFailureDriverNotFound()
 		baseModel{getDriverRegistry: partialFailingRegistry, downloadPkg: downloadTestPkg},
 		false,
 		mockOpenBrowserSuccess,
-		testFallbackUrls,
 	)
 
 	out := suite.runCmdErr(m)
@@ -226,7 +199,6 @@ func (suite *SubcommandTestSuite) TestDocsCompleteRegistryFailure() {
 		baseModel{getDriverRegistry: completeFailingRegistry, downloadPkg: downloadTestPkg},
 		false,
 		mockOpenBrowserSuccess,
-		testFallbackUrls,
 	)
 
 	out := suite.runCmdErr(m)

--- a/cmd/dbc/registry_wiring_test.go
+++ b/cmd/dbc/registry_wiring_test.go
@@ -1587,7 +1587,6 @@ func TestDocsCmdHonorsProjectRegistries(t *testing.T) {
 		baseModel{getDriverRegistry: realRegistryThroughClient(t), downloadPkg: downloadTestPkg},
 		true,
 		func(string) error { return nil },
-		map[string]string{},
 	)
 
 	msg := m.Init()()

--- a/cmd/dbc/subcommand_test.go
+++ b/cmd/dbc/subcommand_test.go
@@ -91,10 +91,9 @@ func downloadTestPkg(pkg dbc.PkgInfo) (*os.File, error) {
 type SubcommandTestSuite struct {
 	suite.Suite
 
-	getDriverRegistryFn   func() ([]dbc.Driver, error)
-	openBrowserFn         func(string) error
-	fallbackDriverDocsUrl map[string]string
-	tempdir               string
+	getDriverRegistryFn func() ([]dbc.Driver, error)
+	openBrowserFn       func(string) error
+	tempdir             string
 
 	configLevel config.ConfigLevel
 }
@@ -103,7 +102,6 @@ func (suite *SubcommandTestSuite) SetupSuite() {
 	suite.getDriverRegistryFn = getDriverRegistry
 	getDriverRegistry = getTestDriverRegistry
 	suite.openBrowserFn = openBrowserFunc
-	suite.fallbackDriverDocsUrl = fallbackDriverDocsUrl
 
 	if suite.configLevel == config.ConfigUnknown {
 		suite.configLevel = config.ConfigEnv
@@ -119,7 +117,6 @@ func (suite *SubcommandTestSuite) SetupTest() {
 func (suite *SubcommandTestSuite) TearDownSuite() {
 	getDriverRegistry = suite.getDriverRegistryFn
 	openBrowserFunc = suite.openBrowserFn
-	fallbackDriverDocsUrl = suite.fallbackDriverDocsUrl
 }
 
 func (suite *SubcommandTestSuite) getFilesInTempDir() []string {


### PR DESCRIPTION
Removes the fallback URL functionality from the `dbc docs` subcommand. We needed this in the past because the Columnar driver CDN didn't have a method to enforce that every driver has a documentation URL. We now do and it's enforced in pre-commit and in CI. The behavior for any registry that doesn't set a docs URL for every driver remains unchanged: We still error with a "no documentation available..." error.

Ref https://github.com/columnar-tech/dbc/pull/435#issuecomment-5049497152