### PR TITLE
docs: revert homebrew docs change

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -167,9 +167,7 @@ The following distroless images are available for Linux-based `amd64` and `arm64
 You can install dbc from our Homebrew tap by running:
 
 ```console
-$ brew tap columnar-tech/tap
-$ brew trust columnar-tech/tap
-$ brew install dbc
+$ brew install columnar-tech/tap/dbc
 ```
 
 ## Shell Completions


### PR DESCRIPTION
In e71e9dac047f62b376fc2177a5ba06a2d285bdc8 I changed the homebrew installation instructions to include explicitly trusting our tap. It turns out I was wrong about this so we can revert this back to the simpler form. I've tested this a few times.