### PR TITLE
chore: fixes for goreleaser 2.18.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -242,7 +242,8 @@ snapcrafts:
     icon: ./resources/dbc.png
     hooks:
       install:
-        - network
+        plugs:
+          - network
     base: bare
     confinement: classic
     publish: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -301,7 +301,7 @@ notarize:
         key: "{{ .Env.MACOS_NOTARY_KEY }}"
         key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
         wait: true
-        timeout: 30m
+        timeout: 20m
 
 snapshot:
   version_template: "{{ incpatch .Version }}-snapshot"


### PR DESCRIPTION
Updates our goreleaser config to work under goreleaser 2.18.0.

GoReleaser 2.18.0 made changes to two components that caused our release process to fail:

1. `notarize`: Now errors when the `timeout` param in the `notarize` step is >20m rather than exposing us to a vague error https://github.com/goreleaser/goreleaser/pull/6758
2. `snapcraft`: Caught an YAML syntax error in our `snapcrafts` config that only now gets surfaced. https://github.com/goreleaser/goreleaser/pull/6780

This PR addresses both (1) and (2).

