### PR TITLE
ci: only open one sync_docs pr at a time

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -80,9 +80,10 @@ jobs:
           git commit -m "docs: sync dbc command output"
           git push --force origin "$BRANCH"
 
-          # Open a PR only if one doesn't already exist for this branch.
-          # If it does exist, the force-push above has already updated it.
-          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+          # Open a PR only if there isn't already an open one for this branch.
+          # If there is, the force-push above has already updated it.
+          OPEN_PR_COUNT="$(gh pr list --head "$BRANCH" --base main --state open --limit 1 --json number --jq 'length')"
+          if [ "$OPEN_PR_COUNT" -eq 0 ]; then
             gh pr create \
               --title "docs: sync dbc command output" \
               --body "$PR_BODY" \

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -75,8 +75,22 @@ jobs:
           BRANCH="docs/sync-output"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+
+          # Fetch the remote branch so we can compare docs/ against it.
+          git fetch origin "$BRANCH" 2>/dev/null || true
+
+          # Stage the changes so we can compare against the remote branch.
           git add docs/
+
+          # If the remote branch already has identical docs/ content, the
+          # open PR is already up to date — skip the push to avoid noise.
+          if git rev-parse "origin/$BRANCH" >/dev/null 2>&1 && \
+             git diff --cached --quiet "origin/$BRANCH" -- docs/; then
+            echo "Remote branch already up to date, nothing to push."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH"
           git commit -m "docs: sync dbc command output"
           git push --force origin "$BRANCH"
 

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -72,7 +72,7 @@ jobs:
 
             **Review the diff before merging** to confirm the changes look correct and there are no unexpected formatting regressions.
         run: |
-          BRANCH="docs/sync-output-$(date +%Y-%m-%d)"
+          BRANCH="docs/sync-output"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -81,6 +81,7 @@ jobs:
           git push --force origin "$BRANCH"
 
           # Open a PR only if one doesn't already exist for this branch.
+          # If it does exist, the force-push above has already updated it.
           if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
             gh pr create \
               --title "docs: sync dbc command output" \


### PR DESCRIPTION
The Sync Docs job can open multiple PRs if existing ones aren't merged before it runs again. This PR makes it so there's only ever one sync PR open at a time by:

1. Using a common branch name instead of one keyed to the calendar date
2. When the CI runs, if there are no new changes since the last run, we finish. If there are changes, we commit and force push to the branch.